### PR TITLE
feat: update PHP and Symfony requirements

### DIFF
--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -1,8 +1,38 @@
 <?php
 
 $finder = PhpCsFixer\Finder::create()
-    ->in([__DIR__.'/src', __DIR__.'/tests']);
+    ->in(__DIR__ . '/src')
+    ->in(__DIR__ . '/tests');
+
+$rules = [
+    '@PER-CS2x0' => true,
+    '@PER-CS2x0:risky' => true,
+    'array_syntax' => ['syntax' => 'short'],
+    'align_multiline_comment' => true,
+    'cast_spaces' => true,
+    'no_empty_comment' => true,
+    'no_unused_imports' => true,
+    'phpdoc_scalar' => true,
+    'phpdoc_single_line_var_spacing' => true,
+    'phpdoc_trim' => true,
+    'phpdoc_var_annotation_correct_order' => true,
+    'no_empty_statement' => true,
+    'no_spaces_around_offset' => true,
+    'declare_strict_types' => true,
+    'strict_comparison' => true,
+    'ordered_imports' => true,
+    'get_class_to_class_keyword' => true,
+    'no_superfluous_phpdoc_tags' => true,
+    'trailing_comma_in_multiline' => [
+        'after_heredoc' => true,
+        'elements' => ['arrays', 'match', 'arguments', 'parameters'],
+    ],
+    'single_line_empty_body' => false,
+];
 
 return (new PhpCsFixer\Config())
-    ->setRules(['@Symfony' => true])
-    ->setFinder($finder);
+    ->setCacheFile(__DIR__ . '/var/.php-cs-fixer.cache')
+    ->setFinder($finder)
+    ->setRules($rules)
+    ->setRiskyAllowed(true)
+    ->setUnsupportedPhpVersionAllowed(true);

--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,15 @@
 {
+    "name": "crazy-goat/the-consoomer",
+    "description": "Symfony Messenger AMQP transport using consume instead of get",
+    "type": "library",
+    "license": "MIT",
+    "keywords": ["symfony", "messenger", "amqp", "rabbitmq", "transport"],
+    "authors": [
+        {
+            "name": "Piotr Hałas",
+            "email": "piotr.halas@crazy-goat.com"
+        }
+    ],
     "autoload":{
         "psr-4": {
             "CrazyGoat\\TheConsoomer\\": "src/"
@@ -10,11 +21,13 @@
         }
     },
     "require": {
-        "symfony/messenger": "^7.2"
+        "php": "^8.2",
+        "ext-amqp": "*",
+        "symfony/messenger": "^6.4 || ^7.4 || ^8.0"
     },
     "require-dev": {
-        "symfony/console": "^7.2",
-        "symfony/dependency-injection": "^7.2",
+        "symfony/console": "^6.4 || ^7.4 || ^8.0",
+        "symfony/dependency-injection": "^6.4 || ^7.4 || ^8.0",
         "friendsofphp/php-cs-fixer": "^3.75",
         "rector/rector": "^2.0",
         "phpunit/phpunit": "^10"

--- a/rector.php
+++ b/rector.php
@@ -1,18 +1,13 @@
 <?php
 
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\SetList;
-use Rector\Symfony\Set\SymfonySetList;
-use Rector\TypeDeclaration\Rector\Property\TypedPropertyFromStrictConstructorRector;
 
 return RectorConfig::configure()
     ->withPaths([
         __DIR__ . '/src',
-        __DIR__ . '/examples',
+        __DIR__ . '/tests',
     ])
-    // register single rule
-    ->withPhpSets(php84: true)
-    // here we can define, what prepared sets of rules will be applied
+    ->withPhpSets(php82: true)
     ->withPreparedSets(
         deadCode: true,
         codeQuality: true,

--- a/src/AmqpTransport.php
+++ b/src/AmqpTransport.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CrazyGoat\TheConsoomer;
 
 use Psr\Log\NullLogger;
@@ -61,7 +63,7 @@ class AmqpTransport implements TransportInterface, TransportFactoryInterface
         $connection->setVhost($mergedOptions['vhost']);
         $connection->setLogin($info['user']);
         $connection->setPassword($info['pass']);
-        $connection->setReadTimeout($mergedOptions['timeout'] ?? 0.1);
+        $connection->setReadTimeout((float) ($mergedOptions['timeout'] ?? 0.1));
         $connection->connect();
 
         $logger = new NullLogger();

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -16,14 +16,12 @@ class ReceiverTest extends TestCase
     private \AMQPConnection&MockObject $connection;
     private SerializerInterface&MockObject $serializer;
     private \AMQPQueue&MockObject $queue;
-    private \AMQPChannel&MockObject $channel;
 
     protected function setUp(): void
     {
         $this->connection = $this->createMock(\AMQPConnection::class);
         $this->serializer = $this->createMock(SerializerInterface::class);
         $this->queue = $this->createMock(\AMQPQueue::class);
-        $this->channel = $this->createMock(\AMQPChannel::class);
     }
 
     public function testGetReturnsEmptyArrayWhenNoMessage(): void
@@ -67,18 +65,14 @@ class ReceiverTest extends TestCase
 
         $reflection = new \ReflectionClass(Receiver::class);
         $queueProperty = $reflection->getProperty('queue');
-        $queueProperty->setAccessible(true);
         $queueProperty->setValue($receiver, $this->queue);
 
         $callbackProperty = $reflection->getProperty('callback');
-        $callbackProperty->setAccessible(true);
         $callbackProperty->setValue($receiver, function (\AMQPEnvelope $message) use ($receiver, $reflection): false {
             $serializer = $reflection->getProperty('serializer');
-            $serializer->setAccessible(true);
 
             $envelope = $serializer->getValue($receiver)->decode(['body' => $message->getBody()]);
             $messageProperty = $reflection->getProperty('message');
-            $messageProperty->setAccessible(true);
             $messageProperty->setValue($receiver, $envelope->with(new RawMessageStamp($message)));
 
             return false;
@@ -87,7 +81,7 @@ class ReceiverTest extends TestCase
         $this->queue
             ->expects($this->once())
             ->method('consume')
-            ->willReturnCallback(function ($callback) use ($amqpEnvelope) {
+            ->willReturnCallback(function ($callback) use ($amqpEnvelope): void {
                 $callback($amqpEnvelope);
             });
 
@@ -182,7 +176,6 @@ class ReceiverTest extends TestCase
 
         $reflection = new \ReflectionClass(Receiver::class);
         $maxUnackedProperty = $reflection->getProperty('maxUnackedMessages');
-        $maxUnackedProperty->setAccessible(true);
 
         $this->assertSame(100, $maxUnackedProperty->getValue($receiver));
     }
@@ -195,7 +188,6 @@ class ReceiverTest extends TestCase
 
         $reflection = new \ReflectionClass(Receiver::class);
         $maxUnackedProperty = $reflection->getProperty('maxUnackedMessages');
-        $maxUnackedProperty->setAccessible(true);
 
         $this->assertSame(50, $maxUnackedProperty->getValue($receiver));
     }
@@ -208,7 +200,6 @@ class ReceiverTest extends TestCase
 
         $reflection = new \ReflectionClass(Receiver::class);
         $maxUnackedProperty = $reflection->getProperty('maxUnackedMessages');
-        $maxUnackedProperty->setAccessible(true);
 
         $this->assertSame(1, $maxUnackedProperty->getValue($receiver));
     }
@@ -221,7 +212,6 @@ class ReceiverTest extends TestCase
 
         $reflection = new \ReflectionClass(Receiver::class);
         $maxUnackedProperty = $reflection->getProperty('maxUnackedMessages');
-        $maxUnackedProperty->setAccessible(true);
 
         $this->assertSame(1, $maxUnackedProperty->getValue($receiver));
     }
@@ -255,7 +245,6 @@ class ReceiverTest extends TestCase
 
         $reflection = new \ReflectionClass(Receiver::class);
         $queueProperty = $reflection->getProperty('queue');
-        $queueProperty->setAccessible(true);
 
         $this->assertNull($queueProperty->getValue($receiver));
     }
@@ -266,14 +255,10 @@ class ReceiverTest extends TestCase
 
         $reflection = new \ReflectionClass(Receiver::class);
         $queueProperty = $reflection->getProperty('queue');
-        $queueProperty->setAccessible(true);
         $queueProperty->setValue($receiver, $this->queue);
 
         $callbackProperty = $reflection->getProperty('callback');
-        $callbackProperty->setAccessible(true);
-        $callbackProperty->setValue($receiver, function (\AMQPEnvelope $message): false {
-            return false;
-        });
+        $callbackProperty->setValue($receiver, fn (\AMQPEnvelope $message): false => false);
 
         return $receiver;
     }

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -174,7 +174,6 @@ class SenderTest extends TestCase
 
         $reflection = new \ReflectionClass(Sender::class);
         $exchangeProperty = $reflection->getProperty('exchange');
-        $exchangeProperty->setAccessible(true);
         $exchangeProperty->setValue($sender, $this->exchange);
 
         return $sender;


### PR DESCRIPTION
## Summary

- Add minimum PHP version: `^8.2` (supports 8.2, 8.3, 8.4, 8.5)
- Add `ext-amqp` requirement
- Support Symfony versions: `^6.4 || ^7.4 || ^8.0`
- Update rector to target PHP 8.2
- Apply rector fixes (remove `setAccessible()` calls, use arrow functions)

## Supported Versions

| PHP | Status |
|-----|--------|
| 8.2 | Security fixes until Dec 2026 |
| 8.3 | Security fixes until Dec 2027 |
| 8.4 | Active support until Dec 2028 |
| 8.5 | Active support until Dec 2029 |

| Symfony | PHP Required | Status |
|---------|--------------|--------|
| 6.4 | PHP 8.1+ | LTS until Nov 2027 |
| 7.4 | PHP 8.2+ | LTS until Nov 2029 |
| 8.0 | PHP 8.4+ | Stable |