### PR TITLE
feat: split CI into lint, test, e2e jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,26 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress
+
+      - name: Run lint
+        run: composer lint
+
   test:
     runs-on: ubuntu-latest
+    needs: lint
 
     steps:
       - uses: actions/checkout@v4
@@ -23,14 +41,12 @@ jobs:
       - name: Install dependencies
         run: composer install --prefer-dist --no-progress
 
-      - name: Run lint
-        run: composer lint
-
       - name: Run unit tests
         run: composer test-unit
 
   e2e:
     runs-on: ubuntu-latest
+    needs: lint
 
     services:
       rabbitmq:

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CrazyGoat\TheConsoomer;
 
 use Symfony\Component\Messenger\Envelope;

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CrazyGoat\TheConsoomer;
 
 use Symfony\Component\Messenger\Envelope;

--- a/tests/E2E/ConsumeProduceTest.php
+++ b/tests/E2E/ConsumeProduceTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use CrazyGoat\TheConsoomer\AmqpTransport;
@@ -44,7 +46,7 @@ class ConsumeProduceTest extends TestCase
             $port,
             urlencode($vhost),
             self::EXCHANGE_NAME,
-            self::QUEUE_NAME
+            self::QUEUE_NAME,
         );
 
         $serializer = new PhpSerializer();
@@ -91,7 +93,7 @@ class ConsumeProduceTest extends TestCase
             $port,
             urlencode($vhost),
             self::EXCHANGE_NAME,
-            self::QUEUE_NAME
+            self::QUEUE_NAME,
         );
 
         $serializer = new PhpSerializer();
@@ -119,7 +121,7 @@ class ConsumeProduceTest extends TestCase
             $port,
             urlencode($vhost),
             self::EXCHANGE_NAME,
-            self::QUEUE_NAME
+            self::QUEUE_NAME,
         );
 
         $serializer = new PhpSerializer();
@@ -145,7 +147,7 @@ class ConsumeProduceTest extends TestCase
             $port,
             urlencode($vhost),
             self::EXCHANGE_NAME,
-            self::QUEUE_NAME
+            self::QUEUE_NAME,
         );
         $transportWithTimeout = AmqpTransport::create($dsnWithTimeout, [], $serializer);
         $messages = iterator_to_array($transportWithTimeout->get());

--- a/tests/E2E/TestCase.php
+++ b/tests/E2E/TestCase.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use PHPUnit\Framework\TestCase as BaseTestCase;

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -258,7 +258,7 @@ class ReceiverTest extends TestCase
         $queueProperty->setValue($receiver, $this->queue);
 
         $callbackProperty = $reflection->getProperty('callback');
-        $callbackProperty->setValue($receiver, fn (\AMQPEnvelope $message): false => false);
+        $callbackProperty->setValue($receiver, fn(\AMQPEnvelope $message): false => false);
 
         return $receiver;
     }

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -46,7 +46,7 @@ class SenderTest extends TestCase
                 '{"message":"test"}',
                 '',
                 null,
-                ['content-type' => 'application/json']
+                ['content-type' => 'application/json'],
             );
 
         $sender = $this->createSender($options);
@@ -79,7 +79,7 @@ class SenderTest extends TestCase
                 '{"message":"test"}',
                 $routingKey,
                 null,
-                []
+                [],
             );
 
         $sender = $this->createSender($options);
@@ -113,7 +113,7 @@ class SenderTest extends TestCase
                 '{"message":"test"}',
                 'options.routing.key',
                 null,
-                []
+                [],
             );
 
         $sender = $this->createSender($options);
@@ -140,7 +140,7 @@ class SenderTest extends TestCase
                 '{"message":"test"}',
                 '',
                 null,
-                []
+                [],
             );
 
         $sender = $this->createSender($options);


### PR DESCRIPTION
## Summary

- Split CI into 3 jobs: `lint`, `test`, `e2e`
- `lint` runs first (rector + cs-fixer)
- `test` and `e2e` depend on `lint` passing
- Update branch protection to require all 3 checks
- Apply cs-fixer fixes (declare_strict_types)

## CI Pipeline

```
lint ──> test
   └───> e2e
```

Tests only run if lint passes.