### PR TITLE
refactor: combine unit and e2e tests in single job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,39 +39,6 @@ jobs:
           - php: '8.3'
             symfony: '8.0'
 
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: ${{ matrix.php }}
-          extensions: amqp
-          coverage: xdebug
-
-      - name: Install dependencies
-        run: |
-          composer require symfony/messenger:^${{ matrix.symfony }} symfony/console:^${{ matrix.symfony }} symfony/dependency-injection:^${{ matrix.symfony }} --no-interaction
-          composer install --prefer-dist --no-progress
-
-      - name: Run unit tests
-        run: composer test-unit
-
-  e2e:
-    runs-on: ubuntu-latest
-    needs: lint
-
-    strategy:
-      fail-fast: false
-      matrix:
-        php: ['8.2', '8.3', '8.4', '8.5']
-        symfony: ['6.4', '7.4', '8.0']
-        exclude:
-          - php: '8.2'
-            symfony: '8.0'
-          - php: '8.3'
-            symfony: '8.0'
-
     services:
       rabbitmq:
         image: rabbitmq:4.1-management-alpine
@@ -90,11 +57,15 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           extensions: amqp
+          coverage: xdebug
 
       - name: Install dependencies
         run: |
           composer require symfony/messenger:^${{ matrix.symfony }} symfony/console:^${{ matrix.symfony }} symfony/dependency-injection:^${{ matrix.symfony }} --no-interaction
           composer install --prefer-dist --no-progress
+
+      - name: Run unit tests
+        run: composer test-unit
 
       - name: Wait for RabbitMQ
         run: |
@@ -120,13 +91,13 @@ jobs:
 
   ci:
     runs-on: ubuntu-latest
-    needs: [lint, test, e2e]
+    needs: [lint, test]
     if: always()
 
     steps:
       - name: Check all jobs passed
         run: |
-          if [[ "${{ needs.test.result }}" != "success" ]] || [[ "${{ needs.e2e.result }}" != "success" ]]; then
+          if [[ "${{ needs.test.result }}" != "success" ]]; then
             echo "Some jobs failed"
             exit 1
           fi


### PR DESCRIPTION
## Summary

- Combine unit and e2e tests into single job per matrix
- Reduce total jobs from 22 to 12
- Unit tests run first, then e2e tests
- Same test matrix: PHP 8.2-8.5, Symfony 6.4-8.0

## Before

```
lint ──> test (10 jobs)
    └──> e2e (10 jobs)
         └──> ci (summary)
```

Total: 22 jobs

## After

```
lint ──> test (10 jobs: unit + e2e)
         └──> ci (summary)
```

Total: 12 jobs

## Benefits

- Faster CI (less job overhead)
- Clearer test flow (unit → e2e)
- Same coverage