### PR TITLE
fix(#45): reverse options merge order - programmatic options now override DSN values

### DIFF
--- a/src/AmqpTransport.php
+++ b/src/AmqpTransport.php
@@ -71,7 +71,7 @@ class AmqpTransport implements TransportInterface, TransportFactoryInterface, Me
     {
         $dsnParser = new DsnParser();
         $parsedDsn = $dsnParser->parse($dsn);
-        $mergedOptions = [...$options, ...$parsedDsn];
+        $mergedOptions = [...$parsedDsn, ...$options];
 
         $factory ??= new AmqpFactory();
 
@@ -79,6 +79,9 @@ class AmqpTransport implements TransportInterface, TransportFactoryInterface, Me
         // Set via constructor to ensure RabbitMQ sees the heartbeat value
         $connection = $factory->createConnection($mergedOptions);
 
+        // Connection parameters (host, port, vhost, user, password, timeout) are always
+        // taken from $parsedDsn, not from $mergedOptions. These are part of the DSN
+        // authority/path and cannot be overridden by programmatic $options.
         $connection->setHost($parsedDsn['host']);
         $connection->setPort($parsedDsn['port']);
         $connection->setVhost($parsedDsn['vhost']);

--- a/tests/Unit/AmqpTransportTest.php
+++ b/tests/Unit/AmqpTransportTest.php
@@ -307,6 +307,38 @@ class AmqpTransportTest extends TestCase
         $this->assertSame(0, $transport->getMessageCount());
     }
 
+    public function testCreateMergesOptionsWithProgrammaticOptionsTakingPrecedence(): void
+    {
+        $factory = $this->createMock(AmqpFactoryInterface::class);
+        $connection = $this->createMock(\AMQPConnection::class);
+        $serializer = $this->createMock(SerializerInterface::class);
+
+        $factory
+            ->expects($this->once())
+            ->method('createConnection')
+            ->with(
+                $this->callback(function (array $options): true {
+                    // Programmatic options (retry_count=5) should override DSN options (retry_count=3)
+                    $this->assertSame(5, $options['retry_count']);
+                    // DSN options should still be present if not overridden (DsnParser normalizes numeric strings to int)
+                    $this->assertSame(100000, $options['retry_delay']);
+                    return true;
+                }),
+            )
+            ->willReturn($connection);
+
+        $connection
+            ->expects($this->once())
+            ->method('connect');
+
+        AmqpTransport::create(
+            'amqp-consoomer://guest:guest@localhost:5672/%2f/exchange?retry_count=3&retry_delay=100000',
+            ['exchange' => 'test-exchange', 'queue' => 'test-queue', 'retry_count' => 5],  // This should override DSN's retry_count=3
+            $serializer,
+            $factory,
+        );
+    }
+
     public function testSetupDelegatesToInfrastructureSetup(): void
     {
         $this->setup


### PR DESCRIPTION
## Problem

In `AmqpTransport::create()`, DSN-parsed values were overriding programmatic `$options` passed to the method:

```php
$mergedOptions = [...$options, ...$parsedDsn];  // DSN wins - wrong!
```

This was counterintuitive - explicit code-level options should take precedence over DSN query parameters.

## Example

```php
AmqpTransport::create(
    'amqp-consoomer://localhost/%2f/exchange?retry_count=3',
    ['retry_count' => 5],  // This was getting overridden by DSN's 3
    $serializer,
);
```

## Solution

Reversed the spread order:

```php
$mergedOptions = [...$parsedDsn, ...$options];  // Programmatic options win - correct!
```

Now programmatic options override DSN defaults, following the standard convention used by Symfony Mailer, Doctrine DBAL, etc.

## Changes

- **src/AmqpTransport.php**: Fixed merge order on line 74
- **tests/Unit/AmqpTransportTest.php**: Added `testCreateMergesOptionsWithProgrammaticOptionsTakingPrecedence()` to verify the fix

## Testing

All 137 unit tests pass with 283 assertions.

Fixes #45