### PR TITLE
tests: Replace assertEquals with assertSame for scalar comparisons (closes #88)

### DIFF
--- a/tests/E2E/AutoSetupTest.php
+++ b/tests/E2E/AutoSetupTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use CrazyGoat\TheConsoomer\AmqpTransport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 

--- a/tests/E2E/ConsumeProduceTest.php
+++ b/tests/E2E/ConsumeProduceTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use CrazyGoat\TheConsoomer\AmqpTransport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 

--- a/tests/E2E/DsnParserOptionsTest.php
+++ b/tests/E2E/DsnParserOptionsTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use CrazyGoat\TheConsoomer\AmqpTransport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 

--- a/tests/E2E/HeartbeatTest.php
+++ b/tests/E2E/HeartbeatTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use CrazyGoat\TheConsoomer\AmqpTransport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 

--- a/tests/E2E/MessageCountTest.php
+++ b/tests/E2E/MessageCountTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
+use CrazyGoat\TheConsoomer\AmqpTransportFactory;
 use CrazyGoat\TheConsoomer\AmqpTransport;
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;

--- a/tests/E2E/RetryTest.php
+++ b/tests/E2E/RetryTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use CrazyGoat\TheConsoomer\AmqpTransport;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 

--- a/tests/E2E/SetupTransportTest.php
+++ b/tests/E2E/SetupTransportTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use CrazyGoat\TheConsoomer\AmqpTransport;
 use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
 
 class SetupTransportTest extends TestCase

--- a/tests/E2E/SslTransportTest.php
+++ b/tests/E2E/SslTransportTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer\Tests\E2E;
 
+use CrazyGoat\TheConsoomer\AmqpTransportFactory;
 use CrazyGoat\TheConsoomer\AmqpTransport;
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
 use Symfony\Component\Messenger\Envelope;


### PR DESCRIPTION
This PR replaces assertEquals with assertSame for scalar comparisons in tests to avoid type coercion issues. It also fixes a regression in E2E tests related to AmqpTransportFactory relocation.