### PR TITLE
Extract buildDsn() helper to base TestCase (#85)

### DIFF
--- a/tests/E2E/AutoSetupTest.php
+++ b/tests/E2E/AutoSetupTest.php
@@ -29,23 +29,9 @@ class AutoSetupTest extends TestCase
 
     public function testAutoSetupCreatesExchangeAndQueue(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&routing_key=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            $this->queueName,
-            self::ROUTING_KEY,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, $this->queueName, [
+            'routing_key' => self::ROUTING_KEY,
+        ]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);

--- a/tests/E2E/ConsumeProduceTest.php
+++ b/tests/E2E/ConsumeProduceTest.php
@@ -32,22 +32,7 @@ class ConsumeProduceTest extends TestCase
 
     public function testProduceAndConsumeMessage(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
@@ -79,22 +64,7 @@ class ConsumeProduceTest extends TestCase
     {
         $this->purgeQueue(self::QUEUE_NAME);
 
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&timeout=0.1',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['timeout' => 0.1]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
@@ -107,22 +77,7 @@ class ConsumeProduceTest extends TestCase
 
     public function testRejectMessage(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
@@ -139,16 +94,7 @@ class ConsumeProduceTest extends TestCase
         $receivedEnvelope = $messages[0];
         $transport->reject($receivedEnvelope);
 
-        $dsnWithTimeout = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&timeout=0.1',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsnWithTimeout = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['timeout' => 0.1]);
         $transportWithTimeout = AmqpTransportFactory::create($dsnWithTimeout, [], $serializer);
         $messages = iterator_to_array($transportWithTimeout->get());
         $this->assertEmpty($messages);

--- a/tests/E2E/DsnParserOptionsTest.php
+++ b/tests/E2E/DsnParserOptionsTest.php
@@ -29,32 +29,9 @@ class DsnParserOptionsTest extends TestCase
         parent::tearDown();
     }
 
-    private function buildDsn(array $extraParams = []): string
-    {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $params = array_merge(['queue' => self::QUEUE_NAME], $extraParams);
-        $query = http_build_query($params);
-
-        return sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            $query,
-        );
-    }
-
     public function testHeartbeatOption(): void
     {
-        $dsn = $this->buildDsn(['heartbeat' => 60]);
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['heartbeat' => 60]);
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
 
@@ -72,7 +49,7 @@ class DsnParserOptionsTest extends TestCase
 
     public function testTimeoutOptions(): void
     {
-        $dsn = $this->buildDsn([
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
             'timeout' => 0.5,
             'read_timeout' => 1.0,
             'write_timeout' => 1.0,
@@ -99,22 +76,9 @@ class DsnParserOptionsTest extends TestCase
         $this->bindQueue($routingKeyQueue, self::EXCHANGE_NAME, 'custom.routing.key');
 
         try {
-            $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-            $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-            $user = getenv('RABBITMQ_USER') ?: 'guest';
-            $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-            $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-            $dsn = sprintf(
-                'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&routing_key=custom.routing.key',
-                $user,
-                $password,
-                $host,
-                $port,
-                urlencode($vhost),
-                self::EXCHANGE_NAME,
-                $routingKeyQueue,
-            );
+            $dsn = $this->buildDsn(self::EXCHANGE_NAME, $routingKeyQueue, [
+                'routing_key' => 'custom.routing.key',
+            ]);
 
             $serializer = new PhpSerializer();
             $transport = AmqpTransportFactory::create($dsn, [], $serializer);
@@ -136,7 +100,7 @@ class DsnParserOptionsTest extends TestCase
 
     public function testMultipleOptionsCombined(): void
     {
-        $dsn = $this->buildDsn([
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
             'heartbeat' => 30,
             'timeout' => 1.0,
             'max_unacked_messages' => 10,
@@ -158,22 +122,9 @@ class DsnParserOptionsTest extends TestCase
 
     public function testQueueArgumentsParsed(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&queue_arguments[x-max-priority]=10',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'queue_arguments[x-max-priority]' => 10,
+        ]);
 
         $parser = new \CrazyGoat\TheConsoomer\DsnParser();
         $parsed = $parser->parse($dsn);

--- a/tests/E2E/HeartbeatTest.php
+++ b/tests/E2E/HeartbeatTest.php
@@ -30,30 +30,9 @@ class HeartbeatTest extends TestCase
         parent::tearDown();
     }
 
-    private function createDsn(int $heartbeat = 0): string
-    {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        return sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&heartbeat=%d',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-            $heartbeat,
-        );
-    }
-
     public function testHeartbeatEnabledSendsAndReceivesMessage(): void
     {
-        $dsn = $this->createDsn(heartbeat: 60);
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['heartbeat' => 60]);
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
 
@@ -73,7 +52,7 @@ class HeartbeatTest extends TestCase
 
     public function testHeartbeatDisabledWorks(): void
     {
-        $dsn = $this->createDsn(heartbeat: 0);
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['heartbeat' => 0]);
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
 
@@ -93,7 +72,7 @@ class HeartbeatTest extends TestCase
 
     public function testMultipleMessagesWithHeartbeat(): void
     {
-        $dsn = $this->createDsn(heartbeat: 30);
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['heartbeat' => 30]);
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
 
@@ -114,7 +93,7 @@ class HeartbeatTest extends TestCase
 
     public function testSendReceiveAckCycleWithHeartbeat(): void
     {
-        $dsn = $this->createDsn(heartbeat: 60);
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['heartbeat' => 60]);
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
 
@@ -132,7 +111,7 @@ class HeartbeatTest extends TestCase
 
     public function testReconnectsAfterHeartbeatTimeout(): void
     {
-        $dsn = $this->createDsn(heartbeat: 1);
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, ['heartbeat' => 1]);
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
 

--- a/tests/E2E/MessageCountTest.php
+++ b/tests/E2E/MessageCountTest.php
@@ -54,22 +54,7 @@ class MessageCountTest extends TestCase
 
     private function createTransport(): AmqpTransport
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME);
 
         $serializer = new PhpSerializer();
 

--- a/tests/E2E/RetryTest.php
+++ b/tests/E2E/RetryTest.php
@@ -32,22 +32,11 @@ class RetryTest extends TestCase
 
     public function testTransportWithRetryEnabled(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&retry=true&retry_count=3&retry_delay=100000',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'retry' => 'true',
+            'retry_count' => '3',
+            'retry_delay' => '100000',
+        ]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
@@ -71,22 +60,13 @@ class RetryTest extends TestCase
 
     public function testTransportWithRetryAndBackoff(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&retry=true&retry_count=3&retry_backoff=true&retry_jitter=false&retry_max_delay=1000000',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'retry' => 'true',
+            'retry_count' => '3',
+            'retry_backoff' => 'true',
+            'retry_jitter' => 'false',
+            'retry_max_delay' => '1000000',
+        ]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);
@@ -105,22 +85,13 @@ class RetryTest extends TestCase
 
     public function testTransportWithCircuitBreaker(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&retry=true&retry_count=1&retry_circuit_breaker=true&retry_circuit_breaker_threshold=5&retry_circuit_breaker_timeout=60',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'retry' => 'true',
+            'retry_count' => '1',
+            'retry_circuit_breaker' => 'true',
+            'retry_circuit_breaker_threshold' => '5',
+            'retry_circuit_breaker_timeout' => '60',
+        ]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);

--- a/tests/E2E/SetupTransportTest.php
+++ b/tests/E2E/SetupTransportTest.php
@@ -28,23 +28,9 @@ class SetupTransportTest extends TestCase
 
     public function testSetupMethodCreatesExchangeAndQueue(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&routing_key=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            $this->queueName,
-            self::ROUTING_KEY,
-        );
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, $this->queueName, [
+            'routing_key' => self::ROUTING_KEY,
+        ]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);

--- a/tests/E2E/SslTestCase.php
+++ b/tests/E2E/SslTestCase.php
@@ -27,4 +27,28 @@ abstract class SslTestCase extends TestCase
 
         $this->channel = new \AMQPChannel($this->connection);
     }
+
+    protected function buildSslDsn(string $exchange, string $queue, array $extra = []): string
+    {
+        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
+        $port = intval(getenv('RABBITMQ_SSL_PORT') ?: 5671);
+        $user = getenv('RABBITMQ_USER') ?: 'guest';
+        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
+        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
+        $caCert = getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem';
+
+        $params = array_merge(['queue' => $queue, 'ssl_cacert' => $caCert], $extra);
+        $query = http_build_query($params);
+
+        return sprintf(
+            'amqps-consoomer://%s:%s@%s:%d/%s/%s?%s',
+            $user,
+            $password,
+            $host,
+            $port,
+            urlencode($vhost),
+            $exchange,
+            $query,
+        );
+    }
 }

--- a/tests/E2E/SslTestCase.php
+++ b/tests/E2E/SslTestCase.php
@@ -8,45 +8,99 @@ abstract class SslTestCase extends TestCase
 {
     protected function setUp(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_SSL_PORT') ?: 5671);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-        $caCert = getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem';
+        $params = $this->getSslDsnParams();
 
         $this->connection = new \AMQPConnection();
-        $this->connection->setHost($host);
-        $this->connection->setPort($port);
-        $this->connection->setLogin($user);
-        $this->connection->setPassword($password);
-        $this->connection->setVhost($vhost);
-        $this->connection->setCaCert($caCert);
+        $this->connection->setHost($params['host']);
+        $this->connection->setPort($params['port']);
+        $this->connection->setLogin($params['user']);
+        $this->connection->setPassword($params['password']);
+        $this->connection->setVhost($params['vhost']);
+        $this->connection->setCaCert($params['cacert']);
         $this->connection->setVerify(true);
         $this->connection->connect();
 
         $this->channel = new \AMQPChannel($this->connection);
     }
 
+    /**
+     * @return array{host: string, port: int, user: string, password: string, vhost: string, cacert: string}
+     */
+    protected function getSslDsnParams(): array
+    {
+        return [
+            'host' => getenv('RABBITMQ_HOST') ?: 'localhost',
+            'port' => intval(getenv('RABBITMQ_SSL_PORT') ?: 5671),
+            'user' => getenv('RABBITMQ_USER') ?: 'guest',
+            'password' => getenv('RABBITMQ_PASSWORD') ?: 'guest',
+            'vhost' => getenv('RABBITMQ_VHOST') ?: '/',
+            'cacert' => getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem',
+        ];
+    }
+
+    /**
+     * @param array<string, string|int|float> $extra
+     */
     protected function buildSslDsn(string $exchange, string $queue, array $extra = []): string
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_SSL_PORT') ?: 5671);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-        $caCert = getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem';
+        $params = $this->getSslDsnParams();
 
-        $params = array_merge(['queue' => $queue, 'ssl_cacert' => $caCert], $extra);
-        $query = http_build_query($params);
+        $queryParams = array_merge(['queue' => $queue, 'ssl_cacert' => $params['cacert']], $extra);
+        $query = http_build_query($queryParams);
 
         return sprintf(
             'amqps-consoomer://%s:%s@%s:%d/%s/%s?%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
+            $params['user'],
+            $params['password'],
+            $params['host'],
+            $params['port'],
+            urlencode($params['vhost']),
+            $exchange,
+            $query,
+        );
+    }
+
+    /**
+     * @param array<string, string|int|float> $extra
+     */
+    protected function buildSslDsnWithOptions(string $exchange, string $queue, array $extra = []): string
+    {
+        $params = $this->getSslDsnParams();
+
+        $queryParams = array_merge(['ssl_cacert' => $params['cacert']], $extra);
+        $query = http_build_query($queryParams);
+
+        return sprintf(
+            'amqp-consoomer://%s:%s@%s:%d/%s/%s?%s',
+            $params['user'],
+            $params['password'],
+            $params['host'],
+            $params['port'],
+            urlencode($params['vhost']),
+            $exchange,
+            $query,
+        );
+    }
+
+    /**
+     * Build DSN with amqps scheme and no queue in DSN (queue passed to factory separately).
+     *
+     * @param array<string, string|int|float> $extra
+     */
+    protected function buildAmqpsDsn(string $exchange, array $extra = []): string
+    {
+        $params = $this->getSslDsnParams();
+
+        $queryParams = array_merge(['ssl_cacert' => $params['cacert']], $extra);
+        $query = http_build_query($queryParams);
+
+        return sprintf(
+            'amqps-consoomer://%s:%s@%s:%d/%s/%s?%s',
+            $params['user'],
+            $params['password'],
+            $params['host'],
+            $params['port'],
+            urlencode($params['vhost']),
             $exchange,
             $query,
         );

--- a/tests/E2E/SslTransportTest.php
+++ b/tests/E2E/SslTransportTest.php
@@ -32,24 +32,7 @@ class SslTransportTest extends SslTestCase
 
     public function testAmqpsSchemeCreatesTransport(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $sslPort = getenv('RABBITMQ_SSL_PORT') ?: 5671;
-        $port = (int) $sslPort;
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-        $caCert = getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem';
-
-        $dsn = sprintf(
-            'amqps-consoomer://%s:%s@%s:%d/%s/%s?ssl_cacert=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            urlencode($caCert),
-        );
+        $dsn = $this->buildAmqpsDsn(self::EXCHANGE_NAME);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create(
@@ -63,23 +46,9 @@ class SslTransportTest extends SslTestCase
 
     public function testAmqpConsoomerWithSslOption(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $sslPort = intval(getenv('RABBITMQ_SSL_PORT') ?: 5671);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-        $caCert = getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?ssl=true&ssl_cacert=%s',
-            $user,
-            $password,
-            $host,
-            $sslPort,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            urlencode($caCert),
-        );
+        $dsn = $this->buildSslDsnWithOptions(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'ssl' => 'true',
+        ]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create(
@@ -117,24 +86,10 @@ class SslTransportTest extends SslTestCase
 
     public function testSslWithCertificateFiles(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $sslPort = getenv('RABBITMQ_SSL_PORT') ?: 5671;
-        $port = (int) $sslPort;
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-        $caCert = getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem';
-
-        $dsn = sprintf(
-            'amqp-consoomer://%s:%s@%s:%d/%s/%s?ssl=true&ssl_verify=false&ssl_cacert=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            urlencode($caCert),
-        );
+        $dsn = $this->buildSslDsnWithOptions(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'ssl' => 'true',
+            'ssl_verify' => 'false',
+        ]);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create(

--- a/tests/E2E/SslTransportTest.php
+++ b/tests/E2E/SslTransportTest.php
@@ -93,25 +93,7 @@ class SslTransportTest extends SslTestCase
 
     public function testPublishConsumeWithAmqpsScheme(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $sslPort = getenv('RABBITMQ_SSL_PORT') ?: 5671;
-        $port = (int) $sslPort;
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
-        $caCert = getenv('RABBITMQ_SSL_CA_CERT') ?: __DIR__ . '/ssl/ca_certificate.pem';
-
-        $dsn = sprintf(
-            'amqps-consoomer://%s:%s@%s:%d/%s/%s?queue=%s&ssl_cacert=%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
-            self::EXCHANGE_NAME,
-            self::QUEUE_NAME,
-            urlencode($caCert),
-        );
+        $dsn = $this->buildSslDsn(self::EXCHANGE_NAME, self::QUEUE_NAME);
 
         $serializer = new PhpSerializer();
         $transport = AmqpTransportFactory::create($dsn, [], $serializer);

--- a/tests/E2E/TestCase.php
+++ b/tests/E2E/TestCase.php
@@ -13,18 +13,14 @@ abstract class TestCase extends BaseTestCase
 
     protected function setUp(): void
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
+        $params = $this->getDsnParams();
 
         $this->connection = new \AMQPConnection();
-        $this->connection->setHost($host);
-        $this->connection->setPort($port);
-        $this->connection->setLogin($user);
-        $this->connection->setPassword($password);
-        $this->connection->setVhost($vhost);
+        $this->connection->setHost($params['host']);
+        $this->connection->setPort($params['port']);
+        $this->connection->setLogin($params['user']);
+        $this->connection->setPassword($params['password']);
+        $this->connection->setVhost($params['vhost']);
         $this->connection->connect();
 
         $this->channel = new \AMQPChannel($this->connection);
@@ -96,24 +92,37 @@ abstract class TestCase extends BaseTestCase
         $exchange->publish($body, $routingKey);
     }
 
+    /**
+     * @return array{host: string, port: int, user: string, password: string, vhost: string}
+     */
+    protected function getDsnParams(): array
+    {
+        return [
+            'host' => getenv('RABBITMQ_HOST') ?: 'localhost',
+            'port' => intval(getenv('RABBITMQ_PORT') ?: 5672),
+            'user' => getenv('RABBITMQ_USER') ?: 'guest',
+            'password' => getenv('RABBITMQ_PASSWORD') ?: 'guest',
+            'vhost' => getenv('RABBITMQ_VHOST') ?: '/',
+        ];
+    }
+
+    /**
+     * @param array<string, string|int|float> $extra
+     */
     protected function buildDsn(string $exchange, string $queue, array $extra = []): string
     {
-        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
-        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
-        $user = getenv('RABBITMQ_USER') ?: 'guest';
-        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
-        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
+        $params = $this->getDsnParams();
 
-        $params = array_merge(['queue' => $queue], $extra);
-        $query = http_build_query($params);
+        $queryParams = array_merge(['queue' => $queue], $extra);
+        $query = http_build_query($queryParams);
 
         return sprintf(
             'amqp-consoomer://%s:%s@%s:%d/%s/%s?%s',
-            $user,
-            $password,
-            $host,
-            $port,
-            urlencode($vhost),
+            $params['user'],
+            $params['password'],
+            $params['host'],
+            $params['port'],
+            urlencode($params['vhost']),
             $exchange,
             $query,
         );

--- a/tests/E2E/TestCase.php
+++ b/tests/E2E/TestCase.php
@@ -95,4 +95,27 @@ abstract class TestCase extends BaseTestCase
         $exchange->setName($exchangeName);
         $exchange->publish($body, $routingKey);
     }
+
+    protected function buildDsn(string $exchange, string $queue, array $extra = []): string
+    {
+        $host = getenv('RABBITMQ_HOST') ?: 'localhost';
+        $port = intval(getenv('RABBITMQ_PORT') ?: 5672);
+        $user = getenv('RABBITMQ_USER') ?: 'guest';
+        $password = getenv('RABBITMQ_PASSWORD') ?: 'guest';
+        $vhost = getenv('RABBITMQ_VHOST') ?: '/';
+
+        $params = array_merge(['queue' => $queue], $extra);
+        $query = http_build_query($params);
+
+        return sprintf(
+            'amqp-consoomer://%s:%s@%s:%d/%s/%s?%s',
+            $user,
+            $password,
+            $host,
+            $port,
+            urlencode($vhost),
+            $exchange,
+            $query,
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- Extracted duplicated `getenv()` + `sprintf` DSN building code into `buildDsn()` helper in `TestCase`
- Added `buildSslDsn()` helper in `SslTestCase` for SSL tests
- Removed ~170 lines of duplication across 7 test files

## Changes
- `TestCase::buildDsn(string $exchange, string $queue, array $extra = []): string`
- `SslTestCase::buildSslDsn(string $exchange, string $queue, array $extra = []): string`

## Testing
- All 24 E2E tests pass with `composer test-e2e-full`