### PR TITLE
fix: ack consumed messages in E2E RetryTest

### DIFF
--- a/tests/E2E/RetryTest.php
+++ b/tests/E2E/RetryTest.php
@@ -81,6 +81,10 @@ class RetryTest extends TestCase
         $messages = iterator_to_array($messages);
 
         $this->assertCount(1, $messages);
+
+        /** @var Envelope $receivedEnvelope */
+        $receivedEnvelope = $messages[0];
+        $transport->ack($receivedEnvelope);
     }
 
     public function testTransportWithCircuitBreaker(): void
@@ -106,5 +110,9 @@ class RetryTest extends TestCase
         $messages = iterator_to_array($messages);
 
         $this->assertCount(1, $messages);
+
+        /** @var Envelope $receivedEnvelope */
+        $receivedEnvelope = $messages[0];
+        $transport->ack($receivedEnvelope);
     }
 }


### PR DESCRIPTION
## Summary
Fixes #90

Two E2E tests in `RetryTest.php` were not acknowledging consumed messages:
- `testTransportWithRetryAndBackoff()`
- `testTransportWithCircuitBreaker()`

This left messages in an "unacked" state in the RabbitMQ queue, causing potential issues with message accumulation.

## Changes
- Added `$transport->ack($receivedEnvelope)` calls to both tests
- Follows the same pattern used in other E2E tests (e.g., `ConsumeProduceTest`, `AutoSetupTest`)

## Test Plan
- [ ] Run E2E tests: `./vendor/bin/phpunit tests/E2E/RetryTest.php`
- [ ] Verify all tests pass: `./vendor/bin/phpunit`
- [ ] Check that no messages remain unacked in test queues