### PR TITLE
Add namespace to example MyMessage class and rename to RawMessage (#91)

### DIFF
--- a/examples/messenger/common.php
+++ b/examples/messenger/common.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Message;
 
-readonly class RawMessage
+final readonly class RawMessage
 {
     public function __construct(public string $content)
     {

--- a/examples/messenger/common.php
+++ b/examples/messenger/common.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
-final readonly class MyMessage
+namespace App\Message;
+
+readonly class RawMessage
 {
     public function __construct(public string $content)
     {

--- a/examples/messenger/consoomer_consume.php
+++ b/examples/messenger/consoomer_consume.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Message\RawMessage;
 use CrazyGoat\TheConsoomer\AmqpTransportFactory;
 use Symfony\Component\Messenger\Exception\StopWorkerException;
 use Symfony\Component\Messenger\Handler\HandlersLocator;
@@ -13,11 +14,11 @@ use Symfony\Component\Stopwatch\Stopwatch;
 include __DIR__ . '/../../vendor/autoload.php';
 include __DIR__ . '/common.php';
 
-class MyMessageHandler
+class RawMessageHandler
 {
     public static $counter = 0;
 
-    public function __invoke(MyMessage $message): void
+    public function __invoke(RawMessage $message): void
     {
         self::$counter++;
 
@@ -32,7 +33,7 @@ $transport = AmqpTransportFactory::create($dsn, [], new PhpSerializer());
 
 $bus = new MessageBus([
     new HandleMessageMiddleware(
-        new HandlersLocator([MyMessage::class => [new MyMessageHandler()]]),
+        new HandlersLocator([RawMessage::class => [new RawMessageHandler()]]),
     )
 ]);
 
@@ -51,4 +52,4 @@ try {
 }
 
 $time = $stopwatch->stop('consumer')->getDuration();
-printf("Messages processed: %d, time: %.3fs, rate: %d msg/s", MyMessageHandler::$counter, $time / 1000.0, floor((MyMessageHandler::$counter / $time) * 1000));
+printf("Messages processed: %d, time: %.3fs, rate: %d msg/s", RawMessageHandler::$counter, $time / 1000.0, floor((RawMessageHandler::$counter / $time) * 1000));

--- a/examples/messenger/consoomer_publish.php
+++ b/examples/messenger/consoomer_publish.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use App\Message\RawMessage;
+use CrazyGoat\TheConsoomer\AmqpTransportFactory;
 use CrazyGoat\TheConsoomer\AmqpStamp;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;

--- a/examples/messenger/consoomer_publish.php
+++ b/examples/messenger/consoomer_publish.php
@@ -3,7 +3,7 @@
 declare(strict_types=1);
 
 use CrazyGoat\TheConsoomer\AmqpStamp;
-use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use App\Message\RawMessage;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;
@@ -18,13 +18,13 @@ $dsn = 'amqp-consoomer://guest:guest@localhost:5672/%2f/messages?queue=test';
 $transport = AmqpTransportFactory::create($dsn, [], new PhpSerializer());
 
 $container = new ServiceLocator(['consoomer' => fn() => $transport]);
-$senders = new SendersLocator([MyMessage::class => ['consoomer']], $container);
+$senders = new SendersLocator([RawMessage::class => ['consoomer']], $container);
 
 $bus = new MessageBus([
     new SendMessageMiddleware($senders),
 ]);
 
 foreach (range(1, intval($argv[1] ?? 1)) as $i) {
-    $bus->dispatch(new Envelope(new MyMessage('hello'), [new AmqpStamp('test')]));
+    $bus->dispatch(new Envelope(new RawMessage('hello'), [new AmqpStamp('test')]));
 }
-$bus->dispatch(new Envelope(new MyMessage('exit'), [new AmqpStamp('test')]));
+$bus->dispatch(new Envelope(new RawMessage('exit'), [new AmqpStamp('test')]));

--- a/examples/messenger/consoomer_publish.php
+++ b/examples/messenger/consoomer_publish.php
@@ -2,8 +2,8 @@
 
 declare(strict_types=1);
 
-use CrazyGoat\TheConsoomer\AmqpStamp;
 use App\Message\RawMessage;
+use CrazyGoat\TheConsoomer\AmqpStamp;
 use Symfony\Component\DependencyInjection\ServiceLocator;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\MessageBus;


### PR DESCRIPTION
## Summary
- Added `namespace App\Message;` to `examples/messenger/common.php`
- Renamed `MyMessage` to `RawMessage` for consistency with Symfony example (`App\VO\RawMessage`)
- Re-added `final` keyword that was in original `MyMessage` class
- Updated all references in `consoomer_publish.php` and `consoomer_consume.php`
- Sorted imports alphabetically (App < CrazyGoat < Symfony)
- Added trailing newline per PSR-12

## Note on PSR-4
The file is loaded via `include` (not autoloading), so PSR-4 doesn't strictly apply. The namespace was added for consistency with the Symfony example structure and to follow modern PHP conventions.

## Related Issue
Fixes #91