### PR TITLE
Add domain-specific exceptions for ConnectionRetry (fix #55)

### DIFF
--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer;
 
 use CrazyGoat\TheConsoomer\Clock\SystemClock;
+use CrazyGoat\TheConsoomer\Exception\CircuitBreakerOpenException;
+use CrazyGoat\TheConsoomer\Exception\RetryExhaustedException;
 use Psr\Log\LoggerInterface;
 
 class ConnectionRetry implements ConnectionRetryInterface
@@ -49,7 +51,7 @@ class ConnectionRetry implements ConnectionRetryInterface
         if ($this->retryCircuitBreaker && $this->circuitBreaker instanceof \CrazyGoat\TheConsoomer\CircuitBreaker && !$this->circuitBreaker->isAvailable()) {
             $this->logger?->error('Circuit breaker is open, rejecting operation');
             $this->metrics->recordCircuitBreakerOpen();
-            throw new \RuntimeException('Circuit breaker is open');
+            throw new CircuitBreakerOpenException('Circuit breaker is open');
         }
 
         $attempt = 0;
@@ -96,6 +98,15 @@ class ConnectionRetry implements ConnectionRetryInterface
                 ]);
 
                 usleep($delay);
+            } catch (\Throwable $exception) {
+                $this->logger?->warning('Non-AMQP exception during retry', [
+                    'error' => $exception->getMessage(),
+                ]);
+                throw new RetryExhaustedException(
+                    $exception->getMessage(),
+                    $exception->getCode(),
+                    $exception
+                );
             }
         }
 
@@ -110,7 +121,9 @@ class ConnectionRetry implements ConnectionRetryInterface
             'error' => $lastException?->getMessage(),
         ]);
 
-        throw $lastException ?? new \RuntimeException('Operation failed with no retries configured');
+        throw $lastException !== null
+            ? RetryExhaustedException::fromPrevious($lastException)
+            : new RetryExhaustedException();
     }
 
     public function isCircuitOpen(): bool

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -103,11 +103,7 @@ class ConnectionRetry implements ConnectionRetryInterface
                 $this->logger?->warning('Non-AMQP exception during retry', [
                     'error' => $exception->getMessage(),
                 ]);
-                throw new UnexpectedOperationException(
-                    $exception->getMessage(),
-                    $exception->getCode(),
-                    $exception
-                );
+                throw UnexpectedOperationException::fromPrevious($exception);
             }
         }
 

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -118,7 +118,7 @@ class ConnectionRetry implements ConnectionRetryInterface
             'error' => $lastException?->getMessage(),
         ]);
 
-        throw $lastException !== null
+        throw $lastException instanceof \AMQPException
             ? RetryExhaustedException::fromPrevious($lastException)
             : new RetryExhaustedException();
     }

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -7,6 +7,7 @@ namespace CrazyGoat\TheConsoomer;
 use CrazyGoat\TheConsoomer\Clock\SystemClock;
 use CrazyGoat\TheConsoomer\Exception\CircuitBreakerOpenException;
 use CrazyGoat\TheConsoomer\Exception\RetryExhaustedException;
+use CrazyGoat\TheConsoomer\Exception\UnexpectedOperationException;
 use Psr\Log\LoggerInterface;
 
 class ConnectionRetry implements ConnectionRetryInterface
@@ -102,7 +103,7 @@ class ConnectionRetry implements ConnectionRetryInterface
                 $this->logger?->warning('Non-AMQP exception during retry', [
                     'error' => $exception->getMessage(),
                 ]);
-                throw new RetryExhaustedException(
+                throw new UnexpectedOperationException(
                     $exception->getMessage(),
                     $exception->getCode(),
                     $exception

--- a/src/Exception/CircuitBreakerOpenException.php
+++ b/src/Exception/CircuitBreakerOpenException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer\Exception;
+
+class CircuitBreakerOpenException extends \RuntimeException
+{
+}

--- a/src/Exception/RetryExhaustedException.php
+++ b/src/Exception/RetryExhaustedException.php
@@ -11,7 +11,7 @@ class RetryExhaustedException extends \RuntimeException
     public function __construct(
         string $message = 'Operation failed with no retries configured',
         int $code = 0,
-        ?Throwable $previous = null
+        ?Throwable $previous = null,
     ) {
         parent::__construct($message, $code, $previous);
     }

--- a/src/Exception/RetryExhaustedException.php
+++ b/src/Exception/RetryExhaustedException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer\Exception;
+
+use Throwable;
+
+class RetryExhaustedException extends \RuntimeException
+{
+    public function __construct(
+        string $message = 'Operation failed with no retries configured',
+        int $code = 0,
+        ?Throwable $previous = null
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+
+    public static function fromPrevious(Throwable $exception): self
+    {
+        return new self($exception->getMessage(), $exception->getCode(), $exception);
+    }
+}

--- a/src/Exception/UnexpectedOperationException.php
+++ b/src/Exception/UnexpectedOperationException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer\Exception;
+
+class UnexpectedOperationException extends \RuntimeException
+{
+}

--- a/src/Exception/UnexpectedOperationException.php
+++ b/src/Exception/UnexpectedOperationException.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer\Exception;
 
+use Throwable;
+
 class UnexpectedOperationException extends \RuntimeException
 {
+    public static function fromPrevious(Throwable $exception): self
+    {
+        return new self($exception->getMessage(), $exception->getCode(), $exception);
+    }
 }

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -8,6 +8,7 @@ use CrazyGoat\TheConsoomer\CircuitState;
 use CrazyGoat\TheConsoomer\ConnectionRetry;
 use CrazyGoat\TheConsoomer\Exception\CircuitBreakerOpenException;
 use CrazyGoat\TheConsoomer\Exception\RetryExhaustedException;
+use CrazyGoat\TheConsoomer\Exception\UnexpectedOperationException;
 use CrazyGoat\TheConsoomer\Tests\Unit\Clock\FrozenClock;
 use PHPUnit\Framework\TestCase;
 
@@ -75,7 +76,7 @@ class ConnectionRetryTest extends TestCase
     {
         $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
 
-        $this->expectException(RetryExhaustedException::class);
+        $this->expectException(UnexpectedOperationException::class);
 
         $retry->withRetry(function (): void {
             throw new \RuntimeException('Other error');

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -6,6 +6,8 @@ namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\CircuitState;
 use CrazyGoat\TheConsoomer\ConnectionRetry;
+use CrazyGoat\TheConsoomer\Exception\CircuitBreakerOpenException;
+use CrazyGoat\TheConsoomer\Exception\RetryExhaustedException;
 use CrazyGoat\TheConsoomer\Tests\Unit\Clock\FrozenClock;
 use PHPUnit\Framework\TestCase;
 
@@ -29,7 +31,7 @@ class ConnectionRetryTest extends TestCase
     {
         $retry = new ConnectionRetry(retryCount: 0, retryDelay: 1000);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RetryExhaustedException::class);
         $this->expectExceptionMessage('Operation failed with no retries configured');
 
         $retry->withRetry(function (): void {
@@ -42,7 +44,7 @@ class ConnectionRetryTest extends TestCase
         $attempt = 0;
         $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
 
-        $this->expectException(\AMQPConnectionException::class);
+        $this->expectException(RetryExhaustedException::class);
 
         $retry->withRetry(function () use (&$attempt): void {
             $attempt++;
@@ -73,7 +75,7 @@ class ConnectionRetryTest extends TestCase
     {
         $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(RetryExhaustedException::class);
 
         $retry->withRetry(function (): void {
             throw new \RuntimeException('Other error');
@@ -85,7 +87,7 @@ class ConnectionRetryTest extends TestCase
         $attempt = 0;
         $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
 
-        $this->expectException(\AMQPChannelException::class);
+        $this->expectException(RetryExhaustedException::class);
 
         $retry->withRetry(function () use (&$attempt): void {
             $attempt++;
@@ -100,7 +102,7 @@ class ConnectionRetryTest extends TestCase
         $attempt = 0;
         $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
 
-        $this->expectException(\AMQPExchangeException::class);
+        $this->expectException(RetryExhaustedException::class);
 
         $retry->withRetry(function () use (&$attempt): void {
             $attempt++;
@@ -115,7 +117,7 @@ class ConnectionRetryTest extends TestCase
         $attempt = 0;
         $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
 
-        $this->expectException(\AMQPQueueException::class);
+        $this->expectException(RetryExhaustedException::class);
 
         $retry->withRetry(function () use (&$attempt): void {
             $attempt++;
@@ -224,7 +226,8 @@ class ConnectionRetryTest extends TestCase
                 $retry->withRetry(function (): void {
                     throw new \AMQPConnectionException('Connection failed');
                 });
-            } catch (\AMQPConnectionException) {
+            } catch (RetryExhaustedException $e) {
+                $this->assertInstanceOf(\AMQPConnectionException::class, $e->getPrevious());
             }
         }
 
@@ -249,7 +252,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (\AMQPConnectionException) {
+        } catch (RetryExhaustedException $e) {
         }
 
         $this->assertTrue($retry->isCircuitOpen());
@@ -276,7 +279,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (\AMQPConnectionException) {
+        } catch (RetryExhaustedException $e) {
         }
 
         $totalTime = (microtime(true) - $startTime) * 1000000;
@@ -301,7 +304,7 @@ class ConnectionRetryTest extends TestCase
                     $attempt++;
                     throw new \AMQPConnectionException('Connection failed');
                 });
-            } catch (\AMQPConnectionException) {
+            } catch (RetryExhaustedException $e) {
             }
         }
 
@@ -321,7 +324,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (\AMQPConnectionException) {
+        } catch (RetryExhaustedException $e) {
         }
 
         $this->assertTrue($retry->isCircuitOpen());
@@ -372,7 +375,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (\AMQPConnectionException) {
+        } catch (RetryExhaustedException $e) {
         }
 
         $this->assertTrue($retry->isCircuitOpen());
@@ -407,7 +410,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (\AMQPConnectionException) {
+        } catch (RetryExhaustedException $e) {
         }
 
         $clock->advance(3);

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -6,7 +6,6 @@ namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\CircuitState;
 use CrazyGoat\TheConsoomer\ConnectionRetry;
-use CrazyGoat\TheConsoomer\Exception\CircuitBreakerOpenException;
 use CrazyGoat\TheConsoomer\Exception\RetryExhaustedException;
 use CrazyGoat\TheConsoomer\Exception\UnexpectedOperationException;
 use CrazyGoat\TheConsoomer\Tests\Unit\Clock\FrozenClock;
@@ -253,7 +252,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (RetryExhaustedException $e) {
+        } catch (RetryExhaustedException) {
         }
 
         $this->assertTrue($retry->isCircuitOpen());
@@ -280,7 +279,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (RetryExhaustedException $e) {
+        } catch (RetryExhaustedException) {
         }
 
         $totalTime = (microtime(true) - $startTime) * 1000000;
@@ -305,7 +304,7 @@ class ConnectionRetryTest extends TestCase
                     $attempt++;
                     throw new \AMQPConnectionException('Connection failed');
                 });
-            } catch (RetryExhaustedException $e) {
+            } catch (RetryExhaustedException) {
             }
         }
 
@@ -325,7 +324,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (RetryExhaustedException $e) {
+        } catch (RetryExhaustedException) {
         }
 
         $this->assertTrue($retry->isCircuitOpen());
@@ -376,7 +375,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (RetryExhaustedException $e) {
+        } catch (RetryExhaustedException) {
         }
 
         $this->assertTrue($retry->isCircuitOpen());
@@ -411,7 +410,7 @@ class ConnectionRetryTest extends TestCase
             $retry->withRetry(function (): void {
                 throw new \AMQPConnectionException('Connection failed');
             });
-        } catch (RetryExhaustedException $e) {
+        } catch (RetryExhaustedException) {
         }
 
         $clock->advance(3);


### PR DESCRIPTION
## Summary
- Add `CircuitBreakerOpenException` - thrown when circuit breaker rejects operation
- Add `RetryExhaustedException` - wraps original exception when all retries are exhausted
- Replace generic `\RuntimeException` throws with domain-specific exceptions
- Non-AMQP exceptions are now properly wrapped in `RetryExhaustedException`

## Files Changed
- `src/Exception/CircuitBreakerOpenException.php` (new)
- `src/Exception/RetryExhaustedException.php` (new)
- `src/ConnectionRetry.php` - uses new exceptions
- `tests/Unit/ConnectionRetryTest.php` - updated to expect new exception types

Fixes #55