### PR TITLE
Remove unused $channel property from Sender (#69)

### DIFF
--- a/src/Sender.php
+++ b/src/Sender.php
@@ -10,7 +10,6 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
 class Sender implements SenderInterface
 {
-    private ?\AMQPChannel $channel = null;
     private ?\AMQPExchange $exchange = null;
 
     public function __construct(
@@ -29,8 +28,7 @@ class Sender implements SenderInterface
             return;
         }
 
-        $this->channel = $this->connection->getChannel();
-        $this->exchange = $this->factory->createExchange($this->channel);
+        $this->exchange = $this->factory->createExchange($this->connection->getChannel());
         $this->exchange->setName($this->options['exchange'] ?? '');
     }
 
@@ -38,7 +36,6 @@ class Sender implements SenderInterface
     {
         if ($this->connection->checkHeartbeat()) {
             $this->connection->reconnect();
-            $this->channel = null;
             $this->exchange = null;
             $this->connect();
         }


### PR DESCRIPTION
Fixes #69

## Summary
Removed the unused `` property from the `Sender` class. The property was being set but never read - it was only used temporarily to create the exchange object.

## Changes
- Removed `private ?\AMQPChannel $channel` property
- Simplified `connect()` method to pass channel directly to factory
- Removed `->channel = null` assignment from `ensureConnected()`

## Testing
- All 190 existing tests pass
- PHPStan reports no errors