### PR TITLE
Fix #54: Add MissingStampException for domain-specific error handling

### DIFF
--- a/src/Exception/MissingStampException.php
+++ b/src/Exception/MissingStampException.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer\Exception;
+
+class MissingStampException extends \RuntimeException
+{
+    public function __construct(
+        string $message = 'Missing required stamp',
+        int $code = 0,
+        ?\Throwable $previous = null,
+    ) {
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer;
 
+use CrazyGoat\TheConsoomer\Exception\MissingStampException;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
@@ -102,7 +103,7 @@ class Receiver implements ReceiverInterface, MessageCountAwareInterface
 
         $stamp = $envelope->last(RawMessageStamp::class);
         if (!$stamp instanceof RawMessageStamp) {
-            throw new \RuntimeException('No raw message stamp');
+            throw new MissingStampException('No raw message stamp');
         }
 
         if ($this->retry instanceof \CrazyGoat\TheConsoomer\ConnectionRetryInterface) {
@@ -122,7 +123,7 @@ class Receiver implements ReceiverInterface, MessageCountAwareInterface
 
         $stamp = $envelope->last(RawMessageStamp::class);
         if (!$stamp instanceof RawMessageStamp) {
-            throw new \RuntimeException('No raw message stamp');
+            throw new MissingStampException('No raw message stamp');
         }
 
         if ($this->retry instanceof \CrazyGoat\TheConsoomer\ConnectionRetryInterface) {

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\AmqpFactory;
 use CrazyGoat\TheConsoomer\Connection;
+use CrazyGoat\TheConsoomer\Exception\MissingStampException;
 use CrazyGoat\TheConsoomer\InfrastructureSetup;
 use CrazyGoat\TheConsoomer\RawMessageStamp;
 use CrazyGoat\TheConsoomer\Receiver;
@@ -183,7 +184,7 @@ class ReceiverTest extends TestCase
 
         $envelope = new Envelope(new \stdClass());
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(MissingStampException::class);
         $this->expectExceptionMessage('No raw message stamp');
 
         $receiver->ack($envelope);
@@ -197,7 +198,7 @@ class ReceiverTest extends TestCase
 
         $envelope = new Envelope(new \stdClass());
 
-        $this->expectException(\RuntimeException::class);
+        $this->expectException(MissingStampException::class);
         $this->expectExceptionMessage('No raw message stamp');
 
         $receiver->reject($envelope);


### PR DESCRIPTION
## Summary

Creates a domain-specific `MissingStampException` to replace generic `RuntimeException` in `Receiver::ack()` and `Receiver::reject()`.

## Changes

- **New exception class:** `src/Exception/MissingStampException.php` extending `RuntimeException`
- **Updated:** `src/Receiver.php` - both `ack()` and `reject()` methods now throw `MissingStampException`

## Benefits

- Callers can now catch stamp-related errors distinctly from other runtime errors
- Follows domain-driven design principles
- Consistent with existing exception pattern (RetryExhaustedException, CircuitBreakerOpenException)

## Testing

All 190 tests pass (392 assertions).

Closes #54