### PR TITLE
Fix: Catch AMQPConnectionException instead of generic Exception in reconnect()

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -82,9 +82,9 @@ class Connection
             }
             $this->lastActivityTime = time();
             $this->logger?->debug('Reconnected successfully');
-        } catch (\Exception $e) {
+        } catch (\AMQPConnectionException $e) {
             $this->logger?->error('Reconnect failed: {error}', ['error' => $e->getMessage()]);
-            throw new \AMQPConnectionException('Reconnect failed: ' . $e->getMessage(), 0, $e);
+            throw $e;
         }
 
         // Clear channel cache only after successful reconnect


### PR DESCRIPTION
## Summary
Fixes issue #53

## Changes
- Catches specific \AMQPConnectionException instead of generic \Exception in Connection::reconnect()
- Re-throws the same exception instead of wrapping it in a new AMQPConnectionException

## Why
Catching generic \Exception could swallow unrelated exceptions (e.g., \LogicException, \TypeError) that indicate programming errors rather than connection issues.