### PR TITLE
Add final keyword to source classes (#76)

### DIFF
--- a/src/AmqpTransport.php
+++ b/src/AmqpTransport.php
@@ -11,12 +11,12 @@ use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\SetupableTransportInterface;
 use Symfony\Component\Messenger\Transport\TransportInterface;
 
-class AmqpTransport implements TransportInterface, MessageCountAwareInterface, SetupableTransportInterface
+final readonly class AmqpTransport implements TransportInterface, MessageCountAwareInterface, SetupableTransportInterface
 {
     public function __construct(
-        private readonly ReceiverInterface $receiver,
-        private readonly SenderInterface $sender,
-        private readonly InfrastructureSetup $setup,
+        private ReceiverInterface $receiver,
+        private SenderInterface $sender,
+        private InfrastructureSetupInterface $setup,
     ) {
     }
 

--- a/src/CircuitBreaker.php
+++ b/src/CircuitBreaker.php
@@ -7,7 +7,7 @@ namespace CrazyGoat\TheConsoomer;
 use CrazyGoat\TheConsoomer\Clock\SystemClock;
 use Psr\Log\LoggerInterface;
 
-class CircuitBreaker
+final class CircuitBreaker
 {
     private int $failureCount = 0;
     private int $successCount = 0;

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -6,7 +6,7 @@ namespace CrazyGoat\TheConsoomer;
 
 use Psr\Log\LoggerInterface;
 
-class Connection
+final class Connection implements ConnectionInterface
 {
     private int $heartbeat = 0;
     private int $lastActivityTime;

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer;
+
+interface ConnectionInterface
+{
+    public function getChannel(): \AMQPChannel;
+
+    public function getConnection(): \AMQPConnection;
+
+    public function checkHeartbeat(): bool;
+
+    public function reconnect(): void;
+
+    public function updateActivity(): void;
+
+    public function isConnected(): bool;
+
+    public function setHeartbeat(int $seconds): void;
+
+    public function setLogger(\Psr\Log\LoggerInterface $logger): void;
+
+    public function clearChannelCache(): void;
+}

--- a/src/ConnectionInterface.php
+++ b/src/ConnectionInterface.php
@@ -4,6 +4,12 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer;
 
+use Psr\Log\LoggerInterface;
+
+/**
+ * Interface for AMQP connection wrapper.
+ * Provides connection management, heartbeat tracking, and channel lifecycle.
+ */
 interface ConnectionInterface
 {
     public function getChannel(): \AMQPChannel;
@@ -20,7 +26,7 @@ interface ConnectionInterface
 
     public function setHeartbeat(int $seconds): void;
 
-    public function setLogger(\Psr\Log\LoggerInterface $logger): void;
+    public function setLogger(LoggerInterface $logger): void;
 
     public function clearChannelCache(): void;
 }

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -10,7 +10,7 @@ use CrazyGoat\TheConsoomer\Exception\RetryExhaustedException;
 use CrazyGoat\TheConsoomer\Exception\UnexpectedOperationException;
 use Psr\Log\LoggerInterface;
 
-class ConnectionRetry implements ConnectionRetryInterface
+final class ConnectionRetry implements ConnectionRetryInterface
 {
     /** Jitter variation factor - 25% of delay is used as max variation range */
     public const JITTER_VARIATION_FACTOR = 0.25;

--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer;
 
-class DsnParser
+final class DsnParser
 {
     /** @var list<string> */
     private static ?array $validExchangeTypes = null;

--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -6,7 +6,7 @@ namespace CrazyGoat\TheConsoomer;
 
 use CrazyGoat\TheConsoomer\Enum\ExchangeType;
 
-class InfrastructureSetup
+final class InfrastructureSetup implements InfrastructureSetupInterface
 {
     private bool $setupPerformed = false;
 
@@ -23,7 +23,7 @@ class InfrastructureSetup
      */
     public function __construct(
         private readonly AmqpFactoryInterface $factory,
-        private readonly Connection $connection,
+        private readonly ConnectionInterface $connection,
         private readonly array $options,
     ) {
         if (!isset($options['exchange']) || !isset($options['queue'])) {

--- a/src/InfrastructureSetupInterface.php
+++ b/src/InfrastructureSetupInterface.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer;
+
+interface InfrastructureSetupInterface
+{
+    public function setup(): void;
+}

--- a/src/InfrastructureSetupInterface.php
+++ b/src/InfrastructureSetupInterface.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer;
 
+/**
+ * Interface for AMQP infrastructure setup.
+ * Handles declaration of exchanges, queues, and bindings.
+ */
 interface InfrastructureSetupInterface
 {
     public function setup(): void;

--- a/src/RawMessageStamp.php
+++ b/src/RawMessageStamp.php
@@ -6,9 +6,9 @@ namespace CrazyGoat\TheConsoomer;
 
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
-class RawMessageStamp implements NonSendableStampInterface
+final readonly class RawMessageStamp implements NonSendableStampInterface
 {
-    public function __construct(public readonly \AMQPEnvelope $amqpMessage)
+    public function __construct(public \AMQPEnvelope $amqpMessage)
     {
     }
 }

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -10,7 +10,7 @@ use Symfony\Component\Messenger\Transport\Receiver\MessageCountAwareInterface;
 use Symfony\Component\Messenger\Transport\Receiver\ReceiverInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
-class Receiver implements ReceiverInterface, MessageCountAwareInterface
+final class Receiver implements ReceiverInterface, MessageCountAwareInterface
 {
     public const DEFAULT_MAX_UNACKED_MESSAGES = 100;
     private int $unacked = 0;
@@ -30,10 +30,10 @@ class Receiver implements ReceiverInterface, MessageCountAwareInterface
      */
     public function __construct(
         private readonly AmqpFactoryInterface $factory,
-        private readonly Connection $connection,
+        private readonly ConnectionInterface $connection,
         private readonly SerializerInterface $serializer,
         private readonly array $options,
-        private readonly InfrastructureSetup $setup,
+        private readonly InfrastructureSetupInterface $setup,
         private readonly ?ConnectionRetryInterface $retry = null,
     ) {
         $this->maxUnackedMessages = max(1, intval($this->options['max_unacked_messages'] ?? $this->maxUnackedMessages));

--- a/src/RetryMetrics.php
+++ b/src/RetryMetrics.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace CrazyGoat\TheConsoomer;
 
-class RetryMetrics
+final class RetryMetrics
 {
     private int $totalAttempts = 0;
     private int $successfulRetries = 0;

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -8,7 +8,7 @@ use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Transport\Sender\SenderInterface;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 
-class Sender implements SenderInterface
+final class Sender implements SenderInterface
 {
     private ?\AMQPExchange $exchange = null;
 
@@ -22,10 +22,10 @@ class Sender implements SenderInterface
      */
     public function __construct(
         private readonly AmqpFactoryInterface $factory,
-        private readonly Connection $connection,
+        private readonly ConnectionInterface $connection,
         private readonly SerializerInterface $serializer,
         private readonly array $options,
-        private readonly InfrastructureSetup $setup,
+        private readonly InfrastructureSetupInterface $setup,
         private readonly ?ConnectionRetryInterface $retry = null,
     ) {
     }

--- a/tests/Unit/AmqpTransportTest.php
+++ b/tests/Unit/AmqpTransportTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\AmqpTransport;
-use CrazyGoat\TheConsoomer\InfrastructureSetup;
+use CrazyGoat\TheConsoomer\InfrastructureSetupInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Messenger\Envelope;
@@ -17,13 +17,13 @@ class AmqpTransportTest extends TestCase
 {
     private ReceiverInterface&MockObject $receiver;
     private SenderInterface&MockObject $sender;
-    private InfrastructureSetup&MockObject $setup;
+    private InfrastructureSetupInterface&MockObject $setup;
 
     protected function setUp(): void
     {
         $this->receiver = $this->createMock(ReceiverInterface::class);
         $this->sender = $this->createMock(SenderInterface::class);
-        $this->setup = $this->createMock(InfrastructureSetup::class);
+        $this->setup = $this->createMock(InfrastructureSetupInterface::class);
     }
 
     public function testGetDelegatesToReceiver(): void

--- a/tests/Unit/InfrastructureSetupTest.php
+++ b/tests/Unit/InfrastructureSetupTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\AmqpFactoryInterface;
-use CrazyGoat\TheConsoomer\Connection;
+use CrazyGoat\TheConsoomer\ConnectionInterface;
 use CrazyGoat\TheConsoomer\InfrastructureSetup;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
 class InfrastructureSetupTest extends TestCase
 {
     private AmqpFactoryInterface&MockObject $factory;
-    private Connection&MockObject $connection;
+    private ConnectionInterface&MockObject $connection;
     private \AMQPChannel&MockObject $channel;
     private \AMQPExchange&MockObject $exchange;
     private \AMQPQueue&MockObject $queue;
@@ -21,7 +21,7 @@ class InfrastructureSetupTest extends TestCase
     protected function setUp(): void
     {
         $this->factory = $this->createMock(AmqpFactoryInterface::class);
-        $this->connection = $this->createMock(Connection::class);
+        $this->connection = $this->createMock(ConnectionInterface::class);
         $this->channel = $this->createMock(\AMQPChannel::class);
         $this->exchange = $this->createMock(\AMQPExchange::class);
         $this->queue = $this->createMock(\AMQPQueue::class);

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -5,9 +5,9 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\AmqpFactory;
-use CrazyGoat\TheConsoomer\Connection;
+use CrazyGoat\TheConsoomer\ConnectionInterface;
 use CrazyGoat\TheConsoomer\Exception\MissingStampException;
-use CrazyGoat\TheConsoomer\InfrastructureSetup;
+use CrazyGoat\TheConsoomer\InfrastructureSetupInterface;
 use CrazyGoat\TheConsoomer\RawMessageStamp;
 use CrazyGoat\TheConsoomer\Receiver;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -18,23 +18,23 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 class ReceiverTest extends TestCase
 {
     private AmqpFactory&MockObject $factory;
-    private Connection&MockObject $connection;
+    private ConnectionInterface&MockObject $connection;
     private SerializerInterface&MockObject $serializer;
     private \AMQPQueue&MockObject $queue;
-    private InfrastructureSetup&MockObject $setup;
+    private InfrastructureSetupInterface&MockObject $setup;
 
     protected function setUp(): void
     {
         $this->factory = $this->createMock(AmqpFactory::class);
-        $this->connection = $this->createMock(Connection::class);
+        $this->connection = $this->createMock(ConnectionInterface::class);
         $this->serializer = $this->createMock(SerializerInterface::class);
         $this->queue = $this->createMock(\AMQPQueue::class);
-        $this->setup = $this->createMock(InfrastructureSetup::class);
+        $this->setup = $this->createMock(InfrastructureSetupInterface::class);
     }
 
     public function testGetCallsSetupFirst(): void
     {
-        $setup = $this->createMock(InfrastructureSetup::class);
+        $setup = $this->createMock(InfrastructureSetupInterface::class);
         $setup->expects($this->once())->method('setup');
 
         $channel = $this->createMock(\AMQPChannel::class);
@@ -442,7 +442,7 @@ class ReceiverTest extends TestCase
      */
     public function testGetMessageCountCallsSetupBeforeConnection(): void
     {
-        $setup = $this->createMock(InfrastructureSetup::class);
+        $setup = $this->createMock(InfrastructureSetupInterface::class);
         $setup->expects($this->once())->method('setup');
 
         $channel = $this->createMock(\AMQPChannel::class);

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -6,8 +6,8 @@ namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\AmqpFactory;
 use CrazyGoat\TheConsoomer\AmqpStamp;
-use CrazyGoat\TheConsoomer\Connection;
-use CrazyGoat\TheConsoomer\InfrastructureSetup;
+use CrazyGoat\TheConsoomer\ConnectionInterface;
+use CrazyGoat\TheConsoomer\InfrastructureSetupInterface;
 use CrazyGoat\TheConsoomer\Sender;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -17,18 +17,18 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
 class SenderTest extends TestCase
 {
     private AmqpFactory&MockObject $factory;
-    private Connection&MockObject $connection;
+    private ConnectionInterface&MockObject $connection;
     private SerializerInterface&MockObject $serializer;
     private \AMQPExchange&MockObject $exchange;
-    private InfrastructureSetup&MockObject $setup;
+    private InfrastructureSetupInterface&MockObject $setup;
 
     protected function setUp(): void
     {
         $this->factory = $this->createMock(AmqpFactory::class);
-        $this->connection = $this->createMock(Connection::class);
+        $this->connection = $this->createMock(ConnectionInterface::class);
         $this->serializer = $this->createMock(SerializerInterface::class);
         $this->exchange = $this->createMock(\AMQPExchange::class);
-        $this->setup = $this->createMock(InfrastructureSetup::class);
+        $this->setup = $this->createMock(InfrastructureSetupInterface::class);
     }
 
     public function testSendPublishesToExchange(): void
@@ -276,7 +276,7 @@ class SenderTest extends TestCase
 
     public function testSendCallsSetupFirst(): void
     {
-        $setup = $this->createMock(InfrastructureSetup::class);
+        $setup = $this->createMock(InfrastructureSetupInterface::class);
         $setup->expects($this->once())->method('setup');
 
         $channel = $this->createMock(\AMQPChannel::class);


### PR DESCRIPTION
## Summary

Adds `final` keyword to all source classes that are not designed for extension, as requested in issue #76.

## Changes

### Classes marked as `final`:
- `AmqpTransport` → `final readonly`
- `CircuitBreaker` → `final`
- `Connection` → `final` (with new `ConnectionInterface`)
- `ConnectionRetry` → `final`
- `DsnParser` → `final`
- `InfrastructureSetup` → `final` (with new `InfrastructureSetupInterface`)
- `RawMessageStamp` → `final readonly`
- `Receiver` → `final`
- `RetryMetrics` → `final`
- `Sender` → `final`

### New interfaces:
- `ConnectionInterface` - allows mocking Connection in tests
- `InfrastructureSetupInterface` - allows mocking InfrastructureSetup in tests

### Classes NOT marked as final:
- `AmqpFactory` - implements `AmqpFactoryInterface`, users may provide custom implementations

## Testing

- All 190 unit tests pass
- PHPStan passes with no errors
- Rector passes
- PHP CS Fixer passes

## Breaking Changes

**Potential minor BC break for advanced use cases:**
- Constructor type hints changed from concrete classes to interfaces (`Connection` → `ConnectionInterface`, `InfrastructureSetup` → `InfrastructureSetupInterface`)
- This is safe for contravariance (Connection implements ConnectionInterface), but may affect:
  - Custom DI container configurations that explicitly reference concrete types
  - Code that was incorrectly extending these classes (now prevented by `final`)
  
For 99% of users this is a non-breaking internal improvement.