### PR TITLE
Remove redundant method_exists() tests from AmqpFactoryTest

### DIFF
--- a/tests/Unit/AmqpFactoryTest.php
+++ b/tests/Unit/AmqpFactoryTest.php
@@ -9,36 +9,6 @@ use PHPUnit\Framework\TestCase;
 
 class AmqpFactoryTest extends TestCase
 {
-    public function testFactoryHasCreateConnectionMethod(): void
-    {
-        $factory = new AmqpFactory();
-        $this->assertTrue(method_exists($factory, 'createConnection'));
-    }
-
-    public function testFactoryHasCreateChannelMethod(): void
-    {
-        $factory = new AmqpFactory();
-        $this->assertTrue(method_exists($factory, 'createChannel'));
-    }
-
-    public function testFactoryHasCreateQueueMethod(): void
-    {
-        $factory = new AmqpFactory();
-        $this->assertTrue(method_exists($factory, 'createQueue'));
-    }
-
-    public function testFactoryHasCreateExchangeMethod(): void
-    {
-        $factory = new AmqpFactory();
-        $this->assertTrue(method_exists($factory, 'createExchange'));
-    }
-
-    public function testFactoryHasConfigureSslMethod(): void
-    {
-        $factory = new AmqpFactory();
-        $this->assertTrue(method_exists($factory, 'configureSsl'));
-    }
-
     public function testCreateConnectionWithSslOptions(): void
     {
         $factory = new AmqpFactory();


### PR DESCRIPTION
## Summary
- Removed 5 redundant `method_exists()` tests from `AmqpFactoryTest`
- These tests were unnecessary because `AmqpFactoryInterface` already enforces method existence at compile time
- Kept 7 meaningful SSL configuration tests that verify actual behavior
- Closes #89

## Changes
- `tests/Unit/AmqpFactoryTest.php`: Removed 30 lines of trivial tests