### PR TITLE
Remove redundant normalizeQueueArgumentValue() method (fix #66)

### DIFF
--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -221,23 +221,9 @@ final class DsnParser
     {
         $normalized = [];
         foreach ($arguments as $key => $value) {
-            $normalized[$key] = $this->normalizeQueueArgumentValue($value);
+            $normalized[$key] = $this->normalizeValue($value);
         }
         return $normalized;
-    }
-
-    /**
-     * Normalizes a single queue argument value.
-     *
-     * This method is redundant - it just delegates to normalizeValue().
-     * Kept for potential future customization.
-     *
-     * @param mixed $value Value to normalize
-     * @return mixed Normalized value
-     */
-    private function normalizeQueueArgumentValue(mixed $value): mixed
-    {
-        return $this->normalizeValue($value);
     }
 
     /**


### PR DESCRIPTION
## Summary
- Removes redundant `normalizeQueueArgumentValue()` method that just delegates to `normalizeValue()`
- Direct calls to `normalizeValue()` instead of wrapper method

Closes #66