### PR TITLE
[#71] Standardize null-check style for retry property

### DIFF
--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -126,7 +126,7 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
             throw new MissingStampException('No raw message stamp');
         }
 
-        if ($this->retry instanceof \CrazyGoat\TheConsoomer\ConnectionRetryInterface) {
+        if ($this->retry instanceof ConnectionRetryInterface) {
             $this->retry->withRetry(function () use ($stamp): void {
                 $this->ackMessage($stamp->amqpMessage);
                 $this->connection->updateActivity();
@@ -152,7 +152,7 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
             throw new MissingStampException('No raw message stamp');
         }
 
-        if ($this->retry instanceof \CrazyGoat\TheConsoomer\ConnectionRetryInterface) {
+        if ($this->retry instanceof ConnectionRetryInterface) {
             $this->retry->withRetry(function () use ($stamp): void {
                 $this->ackPending();
                 $this->queue->reject($stamp->amqpMessage->getDeliveryTag());

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -88,7 +88,7 @@ final class Sender implements SenderInterface
             $data['headers'] ?? [],
         );
 
-        if ($this->retry instanceof \CrazyGoat\TheConsoomer\ConnectionRetryInterface) {
+        if ($this->retry instanceof ConnectionRetryInterface) {
             $this->retry->withRetry(function () use ($publishCallback): void {
                 $publishCallback();
                 $this->connection->updateActivity();


### PR DESCRIPTION
Closes #71

Standardizes the null-check style for the "$this->retry" property across Sender and Receiver:

- Removes fully-qualified class names (FQCN) from instanceof checks
- Uses short "ConnectionRetryInterface" form (same namespace, no import needed per project CS rules)

Files changed:
- src/Sender.php
- src/Receiver.php