### PR TITLE
Remove dead code: empty if block in E2E TestCase::tearDown()

### DIFF
--- a/tests/E2E/TestCase.php
+++ b/tests/E2E/TestCase.php
@@ -28,10 +28,6 @@ abstract class TestCase extends BaseTestCase
 
     protected function tearDown(): void
     {
-        if ($this->channel instanceof \AMQPChannel) {
-            // Channel cleanup happens automatically
-        }
-
         if ($this->connection instanceof \AMQPConnection && $this->connection->isConnected()) {
             $this->connection->disconnect();
         }


### PR DESCRIPTION
Closes #86

Removes the no-op `if` block that only contained a comment about channel cleanup happening automatically.