### PR TITLE
[#94] Rename misleading 'stream' naming in Symfony example DSN env var

### DIFF
--- a/examples/symfony/.env
+++ b/examples/symfony/.env
@@ -24,6 +24,6 @@ APP_SECRET=9e0cb315d7f672cc1f55d8e8fd207870
 # MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/messages
 # MESSENGER_TRANSPORT_DSN=redis://localhost:6379/messages
 CONSOOMER_TRANSPORT_DSN=amqp-consoomer://guest:guest@localhost:5672/%2f?queue=test&timeout=5.0
-CONSOOMER_STREAM_TRANSPORT_DSN=amqp-consoomer://guest:guest@localhost:5672/%2f?queue=test-stream&timeout=5.0
+CONSOOMER_EXTRA_TRANSPORT_DSN=amqp-consoomer://guest:guest@localhost:5672/%2f?queue=test-stream&timeout=5.0
 MESSENGER_TRANSPORT_DSN=amqp://guest:guest@localhost:5672/%2f/test
 ###< symfony/messenger ###

--- a/examples/symfony/config/packages/messenger.yaml
+++ b/examples/symfony/config/packages/messenger.yaml
@@ -3,8 +3,8 @@ framework:
         transports:
             the-consoomer:
                 dsn: '%env(CONSOOMER_TRANSPORT_DSN)%'
-            the-consoomer-stream:
-                dsn: '%env(CONSOOMER_STREAM_TRANSPORT_DSN)%'
+            the-consoomer-extra:
+                dsn: '%env(CONSOOMER_EXTRA_TRANSPORT_DSN)%'
             basic:
                 dsn: '%env(MESSENGER_TRANSPORT_DSN)%'
 


### PR DESCRIPTION
Closes #94

```yaml
framework:
    messenger:
        transports:
            the-consoomer:
                dsn: '%env(CONSOOMER_TRANSPORT_DSN)%'
-            the-consoomer-stream:
-                dsn: '%env(CONSOOMER_STREAM_TRANSPORT_DSN)%'
+            the-consoomer-extra:
+                dsn: '%env(CONSOOMER_EXTRA_TRANSPORT_DSN)%'
```

The "stream" naming was misleading because the DSN points to a regular queue (`queue=test-stream`), not a RabbitMQ stream. Renamed to "extra" to avoid confusion.

## Files changed
- `examples/symfony/config/packages/messenger.yaml`
- `examples/symfony/.env`