### PR TITLE
Fix #92: Add type declaration to RawMessageHandler::$counter

### DIFF
--- a/examples/messenger/consoomer_consume.php
+++ b/examples/messenger/consoomer_consume.php
@@ -16,7 +16,7 @@ include __DIR__ . '/common.php';
 
 class RawMessageHandler
 {
-    public static $counter = 0;
+    public static int $counter = 0;
 
     public function __invoke(RawMessage $message): void
     {


### PR DESCRIPTION
## Changes

Added missing `int` type declaration to the static property `$counter` in `RawMessageHandler`.

**Before:**
```php
public static $counter = 0;
```

**After:**
```php
public static int $counter = 0;
```

## Checklist

- [x] Syntax validated with `php -l`
- [x] Fixes #92