### PR TITLE
#32 Default Publish Routing Key

### DIFF
--- a/src/AmqpTransportFactory.php
+++ b/src/AmqpTransportFactory.php
@@ -62,6 +62,7 @@ class AmqpTransportFactory implements TransportFactoryInterface
      *     exchange?: string,
      *     queue?: string,
      *     routing_key?: string,
+     *     default_publish_routing_key?: string,
      *     timeout?: float|int,
      *     exchange_type?: string,
      *     queue_arguments?: array<string, mixed>,

--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -26,6 +26,7 @@ final class DsnParser
      *     exchange_type?: string,
      *     queue?: string,
      *     routing_key?: string,
+     *     default_publish_routing_key?: string,
      *     queues?: array<string, array{binding_keys?: list<string>}>,
      *     queue_arguments?: array<string, mixed>,
      *     max_unacked_messages?: int,

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -66,7 +66,7 @@ final class Sender implements SenderInterface
     /**
      * Resolves the routing key for a message.
      *
-     * Priority: Stamp routing key > Default publish routing key > Empty string
+     * Priority: Stamp routing key > routing_key option > default_publish_routing_key option > Empty string
      */
     private function getRoutingKeyForMessage(?AmqpStamp $stamp): string
     {
@@ -74,7 +74,7 @@ final class Sender implements SenderInterface
             return $stamp->getRoutingKey();
         }
 
-        return $this->options['default_publish_routing_key'] ?? '';
+        return $this->options['routing_key'] ?? $this->options['default_publish_routing_key'] ?? '';
     }
 
     /**

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -22,6 +22,7 @@ final class Sender implements SenderInterface
      * @param array{
      *     exchange?: string,
      *     routing_key?: string,
+     *     default_publish_routing_key?: string,
      *     auto_setup?: bool,
      *     retry?: bool,
      * } $options
@@ -63,6 +64,20 @@ final class Sender implements SenderInterface
     }
 
     /**
+     * Resolves the routing key for a message.
+     *
+     * Priority: Stamp routing key > Default publish routing key > Empty string
+     */
+    private function getRoutingKeyForMessage(?AmqpStamp $stamp): string
+    {
+        if ($stamp instanceof AmqpStamp && $stamp->getRoutingKey() !== null) {
+            return $stamp->getRoutingKey();
+        }
+
+        return $this->options['default_publish_routing_key'] ?? '';
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @param Envelope $envelope The envelope to send
@@ -81,7 +96,7 @@ final class Sender implements SenderInterface
 
         $data = $this->serializer->encode($envelope);
 
-        $routingKey = $stamp?->getRoutingKey() ?? $this->options['routing_key'] ?? '';
+        $routingKey = $this->getRoutingKeyForMessage($stamp);
         $flags = $stamp?->getFlags() ?? \AMQP_NOPARAM;
         $attributes = array_merge($data['headers'] ?? [], $stamp?->getAttributes() ?? []);
 

--- a/tests/Unit/DsnParserTest.php
+++ b/tests/Unit/DsnParserTest.php
@@ -59,6 +59,14 @@ class DsnParserTest extends TestCase
         $this->assertSame('my.key', $result['routing_key']);
     }
 
+    public function testParsesDefaultPublishRoutingKey(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost:5672/%2f/my_exchange?default_publish_routing_key=my.default.key');
+
+        $this->assertSame('my.default.key', $result['default_publish_routing_key']);
+    }
+
     public function testNormalizesQueueArguments(): void
     {
         $parser = new DsnParser();

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -150,15 +150,31 @@ class SenderTest extends TestCase
     public static function routingKeyPrecedenceProvider(): array
     {
         return [
-            'stamp routing key takes precedence over default_publish_routing_key' => [
+            'stamp routing key takes precedence over routing_key' => [
                 'options' => [
                     'exchange' => 'test_exchange',
-                    'default_publish_routing_key' => 'default.routing.key',
+                    'routing_key' => 'options.routing.key',
                 ],
                 'stampRoutingKey' => 'stamp.routing.key',
                 'expectedRoutingKey' => 'stamp.routing.key',
             ],
-            'default_publish_routing_key used when no stamp' => [
+            'routing_key used when no stamp' => [
+                'options' => [
+                    'exchange' => 'test_exchange',
+                    'routing_key' => 'options.routing.key',
+                ],
+                'stampRoutingKey' => null,
+                'expectedRoutingKey' => 'options.routing.key',
+            ],
+            'empty stamp routing key takes precedence over routing_key' => [
+                'options' => [
+                    'exchange' => 'test_exchange',
+                    'routing_key' => 'options.routing.key',
+                ],
+                'stampRoutingKey' => '',
+                'expectedRoutingKey' => '',
+            ],
+            'default_publish_routing_key used when no routing_key' => [
                 'options' => [
                     'exchange' => 'test_exchange',
                     'default_publish_routing_key' => 'default.routing.key',
@@ -166,13 +182,14 @@ class SenderTest extends TestCase
                 'stampRoutingKey' => null,
                 'expectedRoutingKey' => 'default.routing.key',
             ],
-            'empty stamp routing key takes precedence over default_publish_routing_key' => [
+            'routing_key takes precedence over default_publish_routing_key' => [
                 'options' => [
                     'exchange' => 'test_exchange',
+                    'routing_key' => 'options.routing.key',
                     'default_publish_routing_key' => 'default.routing.key',
                 ],
-                'stampRoutingKey' => '',
-                'expectedRoutingKey' => '',
+                'stampRoutingKey' => null,
+                'expectedRoutingKey' => 'options.routing.key',
             ],
         ];
     }

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -150,26 +150,26 @@ class SenderTest extends TestCase
     public static function routingKeyPrecedenceProvider(): array
     {
         return [
-            'stamp routing key takes precedence over options' => [
+            'stamp routing key takes precedence over default_publish_routing_key' => [
                 'options' => [
                     'exchange' => 'test_exchange',
-                    'routing_key' => 'options.routing.key',
+                    'default_publish_routing_key' => 'default.routing.key',
                 ],
                 'stampRoutingKey' => 'stamp.routing.key',
                 'expectedRoutingKey' => 'stamp.routing.key',
             ],
-            'options routing key used when no stamp' => [
+            'default_publish_routing_key used when no stamp' => [
                 'options' => [
                     'exchange' => 'test_exchange',
-                    'routing_key' => 'options.routing.key',
+                    'default_publish_routing_key' => 'default.routing.key',
                 ],
                 'stampRoutingKey' => null,
-                'expectedRoutingKey' => 'options.routing.key',
+                'expectedRoutingKey' => 'default.routing.key',
             ],
-            'empty stamp routing key takes precedence over options' => [
+            'empty stamp routing key takes precedence over default_publish_routing_key' => [
                 'options' => [
                     'exchange' => 'test_exchange',
-                    'routing_key' => 'options.routing.key',
+                    'default_publish_routing_key' => 'default.routing.key',
                 ],
                 'stampRoutingKey' => '',
                 'expectedRoutingKey' => '',

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -191,6 +191,14 @@ class SenderTest extends TestCase
                 'stampRoutingKey' => null,
                 'expectedRoutingKey' => 'options.routing.key',
             ],
+            'stamp routing key takes precedence over default_publish_routing_key' => [
+                'options' => [
+                    'exchange' => 'test_exchange',
+                    'default_publish_routing_key' => 'default.routing.key',
+                ],
+                'stampRoutingKey' => 'stamp.routing.key',
+                'expectedRoutingKey' => 'stamp.routing.key',
+            ],
         ];
     }
 


### PR DESCRIPTION
## Summary

- Add `default_publish_routing_key` option to DsnParser for configuring default routing key when publishing messages
- Update Sender to use `default_publish_routing_key` instead of `routing_key` for publishing (routing_key remains for queue binding in InfrastructureSetup)
- Add `getRoutingKeyForMessage()` method with priority: Stamp routing key > Default publish routing key > Empty string
- Update unit tests to reflect the new behavior

Closes #32