### PR TITLE
#180 Sender: clarify semantics of routing_key vs default_publish_routing_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@
   - `routing_key` is now exclusively used by `Receiver` for queue binding
   - `default_publish_routing_key` is exclusively used by `Sender` for publish routing
   - This prevents unintended coupling between consumer binding and publisher routing
-
-### Changed
 - **BC BREAK**: `AmqpStamp` properties changed from `public` to `private` (#23)
   - Direct property access (`$stamp->routingKey`) no longer works — use `$stamp->getRoutingKey()` instead
   - Default `routingKey` changed from `''` to `null`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 - `Sender::send()` now uses stamp flags and merges stamp attributes with headers
 
 ### Changed
+- **BC BREAK**: `Sender` no longer reads `routing_key` option — use `default_publish_routing_key` for publish defaults (#180)
+  - `routing_key` is now exclusively used by `Receiver` for queue binding
+  - `default_publish_routing_key` is exclusively used by `Sender` for publish routing
+  - This prevents unintended coupling between consumer binding and publisher routing
+
+### Changed
 - **BC BREAK**: `AmqpStamp` properties changed from `public` to `private` (#23)
   - Direct property access (`$stamp->routingKey`) no longer works — use `$stamp->getRoutingKey()` instead
   - Default `routingKey` changed from `''` to `null`

--- a/README.md
+++ b/README.md
@@ -70,6 +70,22 @@ Example: `amqp-consoomer://guest:guest@localhost:5672/%2f/my_exchange/?queue=tes
 | `max_unacked_messages` | Prefetch count / batch size | 100 |
 | `timeout` | Consumer timeout in seconds | 0.1 |
 | `heartbeat` | Connection heartbeat interval in seconds (0 = disabled) | 0 |
+| `routing_key` | **Consumer-side**: binding key used when declaring/binding the queue | `''` |
+| `default_publish_routing_key` | **Sender-side**: default routing key used when publishing messages | `''` |
+
+### Routing Key Resolution
+
+The transport uses separate routing keys for consuming and sending:
+
+- **Consumer (Receiver)**: Uses `routing_key` as the binding key when declaring/binding the queue to an exchange. This determines which messages are routed to the queue.
+- **Sender**: Uses `default_publish_routing_key` as the default routing key when publishing messages. This determines how messages are routed through the exchange.
+
+When sending a message, the routing key precedence is:
+1. `AmqpStamp::getRoutingKey()` — message-specific routing key (highest priority)
+2. `default_publish_routing_key` — configured default for publishing
+3. `''` — empty string (no routing key)
+
+This separation prevents unintended coupling: setting `routing_key` for consumer binding does not affect how messages are published.
 
 ### Heartbeat
 

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -21,7 +21,6 @@ final class Sender implements SenderInterface
     /**
      * @param array{
      *     exchange?: string,
-     *     routing_key?: string,
      *     default_publish_routing_key?: string,
      *     auto_setup?: bool,
      *     retry?: bool,
@@ -66,7 +65,7 @@ final class Sender implements SenderInterface
     /**
      * Resolves the routing key for a message.
      *
-     * Priority: Stamp routing key > routing_key option > default_publish_routing_key option > Empty string
+     * Priority: Stamp routing key > default_publish_routing_key option > Empty string
      */
     private function getRoutingKeyForMessage(?AmqpStamp $stamp): string
     {
@@ -75,7 +74,7 @@ final class Sender implements SenderInterface
             return $routingKey;
         }
 
-        return $this->options['routing_key'] ?? $this->options['default_publish_routing_key'] ?? '';
+        return $this->options['default_publish_routing_key'] ?? '';
     }
 
     /**

--- a/tests/E2E/AutoSetupTest.php
+++ b/tests/E2E/AutoSetupTest.php
@@ -31,6 +31,7 @@ class AutoSetupTest extends TestCase
     {
         $dsn = $this->buildDsn(self::EXCHANGE_NAME, $this->queueName, [
             'routing_key' => self::ROUTING_KEY,
+            'default_publish_routing_key' => self::ROUTING_KEY,
         ]);
 
         $serializer = new PhpSerializer();

--- a/tests/E2E/DsnParserOptionsTest.php
+++ b/tests/E2E/DsnParserOptionsTest.php
@@ -78,6 +78,7 @@ class DsnParserOptionsTest extends TestCase
         try {
             $dsn = $this->buildDsn(self::EXCHANGE_NAME, $routingKeyQueue, [
                 'routing_key' => 'custom.routing.key',
+                'default_publish_routing_key' => 'custom.routing.key',
             ]);
 
             $serializer = new PhpSerializer();

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -150,47 +150,6 @@ class SenderTest extends TestCase
     public static function routingKeyPrecedenceProvider(): array
     {
         return [
-            'stamp routing key takes precedence over routing_key' => [
-                'options' => [
-                    'exchange' => 'test_exchange',
-                    'routing_key' => 'options.routing.key',
-                ],
-                'stampRoutingKey' => 'stamp.routing.key',
-                'expectedRoutingKey' => 'stamp.routing.key',
-            ],
-            'routing_key used when no stamp' => [
-                'options' => [
-                    'exchange' => 'test_exchange',
-                    'routing_key' => 'options.routing.key',
-                ],
-                'stampRoutingKey' => null,
-                'expectedRoutingKey' => 'options.routing.key',
-            ],
-            'empty stamp routing key takes precedence over routing_key' => [
-                'options' => [
-                    'exchange' => 'test_exchange',
-                    'routing_key' => 'options.routing.key',
-                ],
-                'stampRoutingKey' => '',
-                'expectedRoutingKey' => '',
-            ],
-            'default_publish_routing_key used when no routing_key' => [
-                'options' => [
-                    'exchange' => 'test_exchange',
-                    'default_publish_routing_key' => 'default.routing.key',
-                ],
-                'stampRoutingKey' => null,
-                'expectedRoutingKey' => 'default.routing.key',
-            ],
-            'routing_key takes precedence over default_publish_routing_key' => [
-                'options' => [
-                    'exchange' => 'test_exchange',
-                    'routing_key' => 'options.routing.key',
-                    'default_publish_routing_key' => 'default.routing.key',
-                ],
-                'stampRoutingKey' => null,
-                'expectedRoutingKey' => 'options.routing.key',
-            ],
             'stamp routing key takes precedence over default_publish_routing_key' => [
                 'options' => [
                     'exchange' => 'test_exchange',
@@ -198,6 +157,39 @@ class SenderTest extends TestCase
                 ],
                 'stampRoutingKey' => 'stamp.routing.key',
                 'expectedRoutingKey' => 'stamp.routing.key',
+            ],
+            'default_publish_routing_key used when no stamp' => [
+                'options' => [
+                    'exchange' => 'test_exchange',
+                    'default_publish_routing_key' => 'default.routing.key',
+                ],
+                'stampRoutingKey' => null,
+                'expectedRoutingKey' => 'default.routing.key',
+            ],
+            'empty stamp routing key takes precedence over default_publish_routing_key' => [
+                'options' => [
+                    'exchange' => 'test_exchange',
+                    'default_publish_routing_key' => 'default.routing.key',
+                ],
+                'stampRoutingKey' => '',
+                'expectedRoutingKey' => '',
+            ],
+            'routing_key is ignored by Sender (used by Receiver only)' => [
+                'options' => [
+                    'exchange' => 'test_exchange',
+                    'routing_key' => 'options.routing.key',
+                ],
+                'stampRoutingKey' => null,
+                'expectedRoutingKey' => '',
+            ],
+            'routing_key does not affect Sender when both keys are set' => [
+                'options' => [
+                    'exchange' => 'test_exchange',
+                    'routing_key' => 'options.routing.key',
+                    'default_publish_routing_key' => 'default.routing.key',
+                ],
+                'stampRoutingKey' => null,
+                'expectedRoutingKey' => 'default.routing.key',
             ],
         ];
     }


### PR DESCRIPTION
Closes #180

## Summary

Implements **Option A** from the issue - decouples reader and writer concerns in :

-  no longer reads  - this option is now exclusively used by  for queue binding
-  uses only  for publish routing defaults
- This prevents unintended coupling where setting  for consumer binding affects how messages are published

## Changes

- : Updated  to use only 
- : Updated docblock to remove  from options shape
- : Added documentation explaining routing key resolution and precedence
- : Added BC break note
- : Updated test cases to reflect new behavior

## BC Break

**BC BREAK**:  no longer reads  option. Users who were relying on  as a publish default must now use  instead.

Migration:
