### PR TITLE
docs: Prepare CHANGELOG for v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,28 @@
 # Changelog
 
-## [Unreleased]
+## [v0.2.0] - 2026-04-22
 
 ### Added
+- `AmqpReceivedStamp` - new stamp for received messages with queue name and metadata accessors (#25)
+  - Provides `getQueueName()`, `getAmqpEnvelope()` methods
+  - Convenience getters for envelope attributes: `getMessageId()`, `getTimestamp()`, `getAppId()`, `getHeaders()`, `getCorrelationId()`, `getReplyTo()`, `getContentType()`, `getDeliveryMode()`, `getPriority()`
+  - Replaces `RawMessageStamp`
 - `AmqpStamp` extended with full AMQP message attributes support (#23)
   - Added `$flags` (int) and `$attributes` (array) parameters
   - Added getters: `getRoutingKey()`, `getFlags()`, `getAttributes()`
   - Added immutable withers: `withRoutingKey()`, `withFlags()`, `withAttribute()`
   - Added factory methods: `createFromAmqpEnvelope()`, `createWithAttributes()`
 - `Sender::send()` now uses stamp flags and merges stamp attributes with headers
+- `CloseableTransportInterface` support - enables explicit connection closing (#30)
+  - `AmqpTransport::close()` method to disconnect AMQP connection and clear channel cache
+  - `ConnectionInterface::close()` and `Connection::close()` for low-level disconnect
+  - Polyfill for Symfony 6.4 compatibility
+- `default_publish_routing_key` option for `Sender` (#32)
+  - Separate routing key configuration for publishing vs. consumer binding
+  - Backward compatible with existing `routing_key` option
+- Batch fetching in `Receiver::get()` - fetches multiple messages up to `maxUnackedMessages` (#40)
+- Array shape annotations for `AmqpStamp` and `AmqpReceivedStamp` (#182)
+- PHPStan level 3 static analysis support
 
 ### Changed
 - **BC BREAK**: `Sender` no longer reads `routing_key` option — use `default_publish_routing_key` for publish defaults (#180)
@@ -18,6 +32,22 @@
 - **BC BREAK**: `AmqpStamp` properties changed from `public` to `private` (#23)
   - Direct property access (`$stamp->routingKey`) no longer works — use `$stamp->getRoutingKey()` instead
   - Default `routingKey` changed from `''` to `null`
+- **BC BREAK**: `AmqpReceivedStamp` uses private properties with getters only (#184)
+  - Renamed internal `$amqpMessage` to `$envelope` to match `getAmqpEnvelope()` getter
+  - All call sites must use getter methods
+- `AmqpTransport` constructor now requires `InfrastructureSetup` parameter (BC break for direct instantiation)
+- `Receiver::get()` now batch-fetches messages instead of single message retrieval
+- Replaced `eval()`-based `CloseableTransportInterface` polyfill with stub file (#183)
+- Filter numeric fields (`delivery_mode`, `priority`, `timestamp`) when value is `0` in `AmqpStamp::createFromAmqpEnvelope()` (#181)
+
+### Fixed
+- Removed redundant `instanceof` check in `getRoutingKeyForMessage()` (#186)
+- Aligned PHP version constraint in `examples/symfony/composer.json` with root (#173)
+- Non-SSL DSNs now correctly exclude SSL keys (#170)
+
+### Documentation
+- Strengthened `CONTRIBUTING.md` rules on issue selection, CI wait, and merge policy (#171)
+- Added contributing workflow guide (#168)
 
 ## [v0.1.0] - 2026-04-20
 
@@ -25,13 +55,7 @@
 - `AmqpTransport` now implements `SetupableTransportInterface` - enables `bin/console messenger:setup-transports` command
 
 ### Changed
-- **BC BREAK**: `RetryMetrics::getSuccessRate()` renamed to `getRetrySuccessRate()` for clarity (#61)
-- **BC BREAK**: `RetryMetrics::toArray()` key `success_rate` renamed to `retry_success_rate` (#61)
 - `AmqpTransport` constructor now requires `InfrastructureSetup` parameter (BC break for direct instantiation)
-- **BC BREAK**: Routing key precedence changed - `AmqpStamp` routing key now takes precedence over DSN/config options (#62)
-  - Previous: options → stamp → empty
-  - New: stamp → options → empty
-  - This aligns with user expectations where message-specific stamp overrides defaults
 
 ## [v0.1] - 2024-XX-XX
 


### PR DESCRIPTION
## Summary
Prepares the CHANGELOG for the v0.2.0 release milestone.

## Changes in v0.2.0

### Added
- `AmqpReceivedStamp` - new stamp for received messages with queue name and metadata accessors (#25)
- `AmqpStamp` extended with full AMQP message attributes support (#23)
- `CloseableTransportInterface` support - enables explicit connection closing (#30)
- `default_publish_routing_key` option for `Sender` (#32)
- Batch fetching in `Receiver::get()` (#40)
- Array shape annotations for `AmqpStamp` and `AmqpReceivedStamp` (#182)
- PHPStan level 3 static analysis support

### Changed
- **BC BREAK**: `Sender` no longer reads `routing_key` option — use `default_publish_routing_key` for publish defaults (#180)
- **BC BREAK**: `AmqpStamp` properties changed from `public` to `private` (#23)
- **BC BREAK**: `AmqpReceivedStamp` uses private properties with getters only (#184)
- Replaced `eval()`-based `CloseableTransportInterface` polyfill with stub file (#183)
- Filter numeric fields when value is `0` in `AmqpStamp::createFromAmqpEnvelope()` (#181)

### Fixed
- Removed redundant `instanceof` check in `getRoutingKeyForMessage()` (#186)
- Aligned PHP version constraint in examples/symfony/composer.json (#173)
- Non-SSL DSNs now correctly exclude SSL keys (#170)

### Documentation
- Strengthened CONTRIBUTING.md rules (#171)
- Added contributing workflow guide (#168)

## Checklist
- [x] CHANGELOG updated
- [ ] Version tag created after merge