### PR TITLE
#22 Exchange-to-Exchange Bindings

### DIFF
--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -25,6 +25,7 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
      *     queue_arguments?: array<string, mixed>,
      *     exchange_flags?: int,
      *     queue_flags?: int,
+     *     exchange_bindings?: array<array{target: string, routing_keys?: list<string>}>,
      * } $options
      */
     public function __construct(
@@ -34,6 +35,10 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
     ) {
         if (!isset($options['exchange']) || !isset($options['queue'])) {
             throw new \InvalidArgumentException('exchange and queue options are required');
+        }
+
+        if (isset($options['exchange_bindings'])) {
+            $this->validateExchangeBindings($options['exchange_bindings']);
         }
     }
 
@@ -74,6 +79,54 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         $routingKey = $this->options['routing_key'] ?? '';
         $queue->bind($exchange->getName(), $routingKey);
 
+        $this->setupExchangeBindings($exchange);
+
         $this->setupPerformed = true;
+    }
+
+    private function setupExchangeBindings(\AMQPExchange $exchange): void
+    {
+        $bindings = $this->options['exchange_bindings'] ?? [];
+
+        foreach ($bindings as $binding) {
+            $target = $binding['target'];
+            $routingKeys = $binding['routing_keys'] ?? [''];
+
+            foreach ($routingKeys as $routingKey) {
+                $exchange->bind($target, $routingKey);
+            }
+        }
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private function validateExchangeBindings(mixed $bindings): void
+    {
+        if (!is_array($bindings)) {
+            throw new \InvalidArgumentException('exchange_bindings must be an array');
+        }
+
+        foreach ($bindings as $index => $binding) {
+            if (!is_array($binding)) {
+                throw new \InvalidArgumentException(sprintf('exchange_bindings[%d] must be an array', $index));
+            }
+
+            if (!isset($binding['target']) || !is_string($binding['target']) || $binding['target'] === '') {
+                throw new \InvalidArgumentException(sprintf('exchange_bindings[%d].target must be a non-empty string', $index));
+            }
+
+            if (isset($binding['routing_keys'])) {
+                if (!is_array($binding['routing_keys'])) {
+                    throw new \InvalidArgumentException(sprintf('exchange_bindings[%d].routing_keys must be an array', $index));
+                }
+
+                foreach ($binding['routing_keys'] as $keyIndex => $key) {
+                    if (!is_string($key)) {
+                        throw new \InvalidArgumentException(sprintf('exchange_bindings[%d].routing_keys[%d] must be a string', $index, $keyIndex));
+                    }
+                }
+            }
+        }
     }
 }

--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -121,6 +121,10 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
                     throw new \InvalidArgumentException(sprintf('exchange_bindings[%d].routing_keys must be an array', $index));
                 }
 
+                if ($binding['routing_keys'] === []) {
+                    throw new \InvalidArgumentException(sprintf('exchange_bindings[%d].routing_keys must not be empty', $index));
+                }
+
                 foreach ($binding['routing_keys'] as $keyIndex => $key) {
                     if (!is_string($key)) {
                         throw new \InvalidArgumentException(sprintf('exchange_bindings[%d].routing_keys[%d] must be a string', $index, $keyIndex));

--- a/tests/Unit/ExchangeBindingsTest.php
+++ b/tests/Unit/ExchangeBindingsTest.php
@@ -215,6 +215,25 @@ class ExchangeBindingsTest extends TestCase
         new InfrastructureSetup($this->factory, $this->connection, $options);
     }
 
+    public function testValidationThrowsExceptionForEmptyRoutingKeys(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange_bindings[0].routing_keys must not be empty');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => 'target_exchange',
+                    'routing_keys' => [],
+                ],
+            ],
+        ];
+
+        new InfrastructureSetup($this->factory, $this->connection, $options);
+    }
+
     public function testValidationThrowsExceptionForInvalidRoutingKeyType(): void
     {
         $this->expectException(\InvalidArgumentException::class);

--- a/tests/Unit/ExchangeBindingsTest.php
+++ b/tests/Unit/ExchangeBindingsTest.php
@@ -1,0 +1,260 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer\Tests\Unit;
+
+use CrazyGoat\TheConsoomer\AmqpFactoryInterface;
+use CrazyGoat\TheConsoomer\ConnectionInterface;
+use CrazyGoat\TheConsoomer\InfrastructureSetup;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ExchangeBindingsTest extends TestCase
+{
+    private AmqpFactoryInterface&MockObject $factory;
+    private ConnectionInterface&MockObject $connection;
+    private \AMQPChannel&MockObject $channel;
+    private \AMQPExchange&MockObject $exchange;
+    private \AMQPQueue&MockObject $queue;
+
+    protected function setUp(): void
+    {
+        $this->factory = $this->createMock(AmqpFactoryInterface::class);
+        $this->connection = $this->createMock(ConnectionInterface::class);
+        $this->channel = $this->createMock(\AMQPChannel::class);
+        $this->exchange = $this->createMock(\AMQPExchange::class);
+        $this->queue = $this->createMock(\AMQPQueue::class);
+    }
+
+    public function testSetupCreatesExchangeBindings(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')->with($this->channel)->willReturn($this->exchange);
+        $this->factory->method('createQueue')->with($this->channel)->willReturn($this->queue);
+
+        $this->exchange->method('getName')->willReturn('source_exchange');
+
+        $callCount = 0;
+        $this->exchange->expects($this->exactly(2))
+            ->method('bind')
+            ->willReturnCallback(function ($target, $routingKey) use (&$callCount): void {
+                if ($callCount === 0) {
+                    $this->assertSame('target_exchange', $target);
+                    $this->assertSame('routing.key.1', $routingKey);
+                } elseif ($callCount === 1) {
+                    $this->assertSame('target_exchange', $target);
+                    $this->assertSame('routing.key.2', $routingKey);
+                }
+                $callCount++;
+            });
+
+        $options = [
+            'exchange' => 'source_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => 'target_exchange',
+                    'routing_keys' => ['routing.key.1', 'routing.key.2'],
+                ],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupCreatesMultipleExchangeBindings(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')->with($this->channel)->willReturn($this->exchange);
+        $this->factory->method('createQueue')->with($this->channel)->willReturn($this->queue);
+
+        $this->exchange->method('getName')->willReturn('source_exchange');
+
+        $expectedCalls = [
+            ['target_exchange_1', 'key.1'],
+            ['target_exchange_2', 'key.2'],
+            ['target_exchange_2', 'key.3'],
+        ];
+        $callIndex = 0;
+
+        $this->exchange->expects($this->exactly(3))
+            ->method('bind')
+            ->willReturnCallback(function ($target, $routingKey) use ($expectedCalls, &$callIndex): void {
+                $this->assertSame($expectedCalls[$callIndex][0], $target);
+                $this->assertSame($expectedCalls[$callIndex][1], $routingKey);
+                $callIndex++;
+            });
+
+        $options = [
+            'exchange' => 'source_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => 'target_exchange_1',
+                    'routing_keys' => ['key.1'],
+                ],
+                [
+                    'target' => 'target_exchange_2',
+                    'routing_keys' => ['key.2', 'key.3'],
+                ],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithEmptyRoutingKeysUsesEmptyString(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')->with($this->channel)->willReturn($this->exchange);
+        $this->factory->method('createQueue')->with($this->channel)->willReturn($this->queue);
+
+        $this->exchange->method('getName')->willReturn('source_exchange');
+
+        $this->exchange->expects($this->once())
+            ->method('bind')
+            ->with('target_exchange', '');
+
+        $options = [
+            'exchange' => 'source_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => 'target_exchange',
+                ],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testValidationThrowsExceptionForInvalidBindingsType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange_bindings must be an array');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => 'invalid',
+        ];
+
+        new InfrastructureSetup($this->factory, $this->connection, $options);
+    }
+
+    public function testValidationThrowsExceptionForInvalidBindingType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange_bindings[0] must be an array');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => ['invalid'],
+        ];
+
+        new InfrastructureSetup($this->factory, $this->connection, $options);
+    }
+
+    public function testValidationThrowsExceptionForMissingTarget(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange_bindings[0].target must be a non-empty string');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'routing_keys' => ['key.1'],
+                ],
+            ],
+        ];
+
+        new InfrastructureSetup($this->factory, $this->connection, $options);
+    }
+
+    public function testValidationThrowsExceptionForEmptyTarget(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange_bindings[0].target must be a non-empty string');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => '',
+                ],
+            ],
+        ];
+
+        new InfrastructureSetup($this->factory, $this->connection, $options);
+    }
+
+    public function testValidationThrowsExceptionForInvalidRoutingKeysType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange_bindings[0].routing_keys must be an array');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => 'target_exchange',
+                    'routing_keys' => 'invalid',
+                ],
+            ],
+        ];
+
+        new InfrastructureSetup($this->factory, $this->connection, $options);
+    }
+
+    public function testValidationThrowsExceptionForInvalidRoutingKeyType(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('exchange_bindings[0].routing_keys[0] must be a string');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => 'target_exchange',
+                    'routing_keys' => [123],
+                ],
+            ],
+        ];
+
+        new InfrastructureSetup($this->factory, $this->connection, $options);
+    }
+
+    public function testValidationPassesForValidBindings(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')->with($this->channel)->willReturn($this->exchange);
+        $this->factory->method('createQueue')->with($this->channel)->willReturn($this->queue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->expects($this->once())->method('bind')->with('target_exchange', 'key.1');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_bindings' => [
+                [
+                    'target' => 'target_exchange',
+                    'routing_keys' => ['key.1'],
+                ],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+}


### PR DESCRIPTION
Closes #22

## Summary
Implemented exchange-to-exchange bindings support in InfrastructureSetup.

## Changes
- Added  option parsing with validation
- Implemented  method to create bindings between exchanges
- Added comprehensive unit tests for the new functionality

## Options Format


## Testing
- All unit tests pass (221 tests)
- Lint checks pass (phpstan, rector, php-cs-fixer)