### PR TITLE
#29 Queue Purge

### DIFF
--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -236,6 +236,45 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
     }
 
     /**
+     * Removes all messages from the given queue (or the configured queue if none given).
+     *
+     * @param string|null $queueName Queue name to purge, or null to use configured queue
+     *
+     * @return int Number of purged messages
+     *
+     * @throws \AMQPException       When connection fails or purge fails
+     * @throws \InvalidArgumentException When no queue name is provided
+     */
+    public function purgeQueue(?string $queueName = null): int
+    {
+        if ($this->options['auto_setup'] ?? true) {
+            $this->setup->setup();
+        }
+        $this->ensureConnected();
+
+        $queueName ??= $this->options['queue'] ?? '';
+        if ($queueName === '') {
+            throw new \InvalidArgumentException('Queue name must be provided either as argument or in receiver options.');
+        }
+
+        $channel = $this->connection->getChannel();
+        // Create a separate queue object for purge so we don't interfere
+        // with the consuming queue's internal state (consumer tag, flags, etc.)
+        $purgeQueue = $this->factory->createQueue($channel);
+        $purgeQueue->setName($queueName);
+
+        $purgeOperation = (fn(): int => $purgeQueue->purge());
+
+        $result = $this->retry instanceof ConnectionRetryInterface
+            ? $this->retry->withRetry($purgeOperation)
+            : $purgeOperation();
+
+        $this->connection->updateActivity();
+
+        return $result;
+    }
+
+    /**
      * {@inheritdoc}
      *
      * @return int Number of messages in the queue

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -694,6 +694,219 @@ class ReceiverTest extends TestCase
         $this->assertSame(42, $receiver->getMessageCount());
     }
 
+    public function testPurgeQueuePurgingConfiguredQueue(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue
+            ->expects($this->once())
+            ->method('setName')
+            ->with('test_queue');
+        $purgeQueue
+            ->expects($this->once())
+            ->method('purge')
+            ->willReturn(42);
+
+        $this->factory
+            ->expects($this->once())
+            ->method('createQueue')
+            ->with($channel)
+            ->willReturn($purgeQueue);
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $this->assertSame(42, $receiver->purgeQueue());
+    }
+
+    public function testPurgeQueueWithCustomQueueName(): void
+    {
+        $options = ['queue' => 'default_queue'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue
+            ->expects($this->once())
+            ->method('setName')
+            ->with('custom_queue');
+        $purgeQueue
+            ->expects($this->once())
+            ->method('purge')
+            ->willReturn(10);
+
+        $this->factory
+            ->expects($this->once())
+            ->method('createQueue')
+            ->with($channel)
+            ->willReturn($purgeQueue);
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $this->assertSame(10, $receiver->purgeQueue('custom_queue'));
+    }
+
+    public function testPurgeQueueCallsSetupFirst(): void
+    {
+        $setup = $this->createMock(InfrastructureSetupInterface::class);
+        $setup->expects($this->once())->method('setup');
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue->method('purge')->willReturn(0);
+
+        $this->factory
+            ->method('createQueue')
+            ->willReturn($purgeQueue);
+
+        $options = ['queue' => 'test_queue'];
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $setup);
+
+        $receiver->purgeQueue();
+    }
+
+    public function testPurgeQueueCallsUpdateActivity(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue->method('purge')->willReturn(0);
+
+        $this->factory
+            ->method('createQueue')
+            ->willReturn($purgeQueue);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('updateActivity');
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $receiver->purgeQueue();
+    }
+
+    public function testPurgeQueueUsesRetryWhenConfigured(): void
+    {
+        $options = ['queue' => 'test_queue'];
+        $retry = $this->createMock(\CrazyGoat\TheConsoomer\ConnectionRetryInterface::class);
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue->method('purge')->willReturn(42);
+
+        $this->factory
+            ->method('createQueue')
+            ->willReturn($purgeQueue);
+
+        $retry
+            ->expects($this->once())
+            ->method('withRetry')
+            ->willReturnCallback(fn(\Closure $operation): int => $operation());
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup, $retry);
+
+        $this->assertSame(42, $receiver->purgeQueue());
+    }
+
+    public function testPurgeQueueHandlesReconnectionWhenHeartbeatStale(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue->method('purge')->willReturn(42);
+
+        $this->factory
+            ->method('createQueue')
+            ->willReturn($purgeQueue);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('checkHeartbeat')
+            ->willReturn(true);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('reconnect');
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $this->assertSame(42, $receiver->purgeQueue());
+    }
+
+    public function testPurgeQueueThrowsWhenPurgeFails(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue
+            ->expects($this->once())
+            ->method('purge')
+            ->willThrowException(new \AMQPException('Failed to purge queue'));
+
+        $this->factory
+            ->method('createQueue')
+            ->willReturn($purgeQueue);
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $this->expectException(\AMQPException::class);
+        $this->expectExceptionMessage('Failed to purge queue');
+
+        $receiver->purgeQueue();
+    }
+
+    public function testPurgeQueueSkipsSetupWhenAutoSetupDisabled(): void
+    {
+        $setup = $this->createMock(InfrastructureSetupInterface::class);
+        $setup->expects($this->never())->method('setup');
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+
+        $purgeQueue = $this->createMock(\AMQPQueue::class);
+        $purgeQueue->method('purge')->willReturn(0);
+
+        $this->factory
+            ->method('createQueue')
+            ->willReturn($purgeQueue);
+
+        $options = ['queue' => 'test_queue', 'auto_setup' => false];
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $setup);
+
+        $receiver->purgeQueue();
+    }
+
+    public function testPurgeQueueThrowsWhenNoQueueName(): void
+    {
+        $options = [];
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Queue name must be provided');
+
+        $receiver->purgeQueue();
+    }
+
     public function testGetMessageCountCallsUpdateActivity(): void
     {
         $options = ['queue' => 'test_queue'];


### PR DESCRIPTION
Implements `Receiver::purgeQueue()` to remove all messages from a queue.

## Changes

- Added `purgeQueue(?string $queueName = null): int` method to `Receiver`
- Returns the number of purged messages
- Supports optional queue name parameter (falls back to configured queue)
- Uses auto_setup and retry mechanism consistent with existing methods
- Validates that a queue name is available
- Creates a separate queue object to avoid interfering with the consumer queue state

## Tests

- 9 new unit tests covering:
  - Purging configured queue
  - Purging with custom queue name
  - Auto-setup integration
  - Update activity tracking
  - Retry mechanism integration
  - Heartbeat reconnection handling
  - Purge failure error handling
  - Auto-setup disabled path
  - Missing queue name validation

Closes #29