### PR TITLE
feat: add publisher confirms support (#27)

### DIFF
--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -42,6 +42,7 @@ final class DsnParser
      *     retry_circuit_breaker_timeout?: int,
      *     retry_circuit_breaker_success_threshold?: int,
      *     heartbeat?: int,
+     *     confirm_timeout?: float|int,
      *     ssl_cert?: string,
      *     ssl_key?: string,
      *     ssl_cacert?: string,
@@ -125,6 +126,7 @@ final class DsnParser
      *     ssl?: bool,
      *     exchange_type?: string,
      *     queue_arguments?: array<string, mixed>,
+     *     confirm_timeout?: float|int,
      * } $options
      * @return array{
      *     host: string,
@@ -136,6 +138,7 @@ final class DsnParser
      *     ssl?: bool,
      *     exchange_type?: string,
      *     queue_arguments?: array<string, mixed>,
+     *     confirm_timeout?: float|int,
      * }
      * @throws \InvalidArgumentException When exchange is missing or exchange_type is invalid
      */
@@ -235,6 +238,7 @@ final class DsnParser
      *     ssl?: bool,
      *     exchange_type?: string,
      *     queue_arguments?: array<string, mixed>,
+     *     confirm_timeout?: float|int,
      * } $options
      * @deprecated This method is deprecated and will be removed in 0.2.
      *             Validation now happens automatically in parse().

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -12,11 +12,12 @@ use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
  * AMQP message sender for Symfony Messenger.
  *
  * Handles publishing messages to AMQP exchange with support for
- * retry logic and connection recovery.
+ * publisher confirms, retry logic and connection recovery.
  */
 final class Sender implements SenderInterface
 {
     private ?\AMQPExchange $exchange = null;
+    private float $confirmTimeout = 0.0;
 
     /**
      * @param array{
@@ -24,6 +25,7 @@ final class Sender implements SenderInterface
      *     default_publish_routing_key?: string,
      *     auto_setup?: bool,
      *     retry?: bool,
+     *     confirm_timeout?: float|int,
      * } $options
      */
     public function __construct(
@@ -34,6 +36,11 @@ final class Sender implements SenderInterface
         private readonly InfrastructureSetupInterface $setup,
         private readonly ?ConnectionRetryInterface $retry = null,
     ) {
+        $confirmTimeout = $this->options['confirm_timeout'] ?? 0.0;
+        if ($confirmTimeout < 0) {
+            throw new \InvalidArgumentException('confirm_timeout must be a non-negative value');
+        }
+        $this->confirmTimeout = (float) $confirmTimeout;
     }
 
     /**
@@ -100,12 +107,23 @@ final class Sender implements SenderInterface
         $flags = $stamp?->getFlags() ?? \AMQP_NOPARAM;
         $attributes = array_merge($data['headers'] ?? [], $stamp?->getAttributes() ?? []);
 
-        $publishCallback = fn() => $this->exchange->publish(
-            $data['body'],
-            $routingKey,
-            $flags,
-            $attributes,
-        );
+        $publishCallback = function () use ($data, $routingKey, $flags, $attributes): void {
+            if ($this->confirmTimeout > 0.0) {
+                $channel = $this->connection->getChannel();
+                $channel->confirmSelect();
+            }
+
+            $this->exchange->publish(
+                $data['body'],
+                $routingKey,
+                $flags,
+                $attributes,
+            );
+
+            if (isset($channel)) {
+                $channel->waitForConfirm($this->confirmTimeout);
+            }
+        };
 
         if ($this->retry instanceof ConnectionRetryInterface) {
             $this->retry->withRetry(function () use ($publishCallback): void {

--- a/tests/E2E/PublisherConfirmTest.php
+++ b/tests/E2E/PublisherConfirmTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer\Tests\E2E;
+
+use CrazyGoat\TheConsoomer\AmqpTransportFactory;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\Transport\Serialization\PhpSerializer;
+
+class PublisherConfirmTest extends TestCase
+{
+    private const QUEUE_NAME = 'test_pub_confirm_queue';
+    private const EXCHANGE_NAME = 'test_pub_confirm_exchange';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->declareExchange(self::EXCHANGE_NAME);
+        $this->declareQueue(self::QUEUE_NAME);
+        $this->bindQueue(self::QUEUE_NAME, self::EXCHANGE_NAME);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->deleteQueue(self::QUEUE_NAME);
+        $this->deleteExchange(self::EXCHANGE_NAME);
+
+        parent::tearDown();
+    }
+
+    public function testPublishWithConfirmsDeliversMessage(): void
+    {
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'confirm_timeout' => 5,
+            'timeout' => 0.1,
+            'auto_setup' => false,
+        ]);
+
+        $serializer = new PhpSerializer();
+        $transport = AmqpTransportFactory::create($dsn, [], $serializer);
+
+        $testMessage = new \stdClass();
+        $testMessage->content = 'Confirmed message';
+        $envelope = new Envelope($testMessage);
+
+        $transport->send($envelope);
+
+        $messages = $transport->get();
+        $messages = iterator_to_array($messages);
+
+        $this->assertCount(1, $messages);
+
+        /** @var Envelope $receivedEnvelope */
+        $receivedEnvelope = $messages[0];
+        $this->assertSame('Confirmed message', $receivedEnvelope->getMessage()->content);
+        $transport->ack($receivedEnvelope);
+    }
+
+    public function testPublishWithConfirmsAndRetryDeliversMessage(): void
+    {
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'confirm_timeout' => 5,
+            'retry' => true,
+            'timeout' => 0.1,
+            'auto_setup' => false,
+        ]);
+
+        $serializer = new PhpSerializer();
+        $transport = AmqpTransportFactory::create($dsn, [], $serializer);
+
+        $testMessage = new \stdClass();
+        $testMessage->content = 'Confirmed with retry';
+        $envelope = new Envelope($testMessage);
+
+        $transport->send($envelope);
+
+        $messages = $transport->get();
+        $messages = iterator_to_array($messages);
+
+        $this->assertCount(1, $messages);
+
+        /** @var Envelope $receivedEnvelope */
+        $receivedEnvelope = $messages[0];
+        $this->assertSame('Confirmed with retry', $receivedEnvelope->getMessage()->content);
+        $transport->ack($receivedEnvelope);
+    }
+
+    public function testPublishWithoutConfirmsStillWorks(): void
+    {
+        $dsn = $this->buildDsn(self::EXCHANGE_NAME, self::QUEUE_NAME, [
+            'timeout' => 0.1,
+        ]);
+
+        $serializer = new PhpSerializer();
+        $transport = AmqpTransportFactory::create($dsn, [], $serializer);
+
+        $testMessage = new \stdClass();
+        $testMessage->content = 'No confirm message';
+        $envelope = new Envelope($testMessage);
+
+        $transport->send($envelope);
+
+        $messages = $transport->get();
+        $messages = iterator_to_array($messages);
+
+        $this->assertCount(1, $messages);
+
+        /** @var Envelope $receivedEnvelope */
+        $receivedEnvelope = $messages[0];
+        $this->assertSame('No confirm message', $receivedEnvelope->getMessage()->content);
+        $transport->ack($receivedEnvelope);
+    }
+}

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -7,6 +7,7 @@ namespace CrazyGoat\TheConsoomer\Tests\Unit;
 use CrazyGoat\TheConsoomer\AmqpFactory;
 use CrazyGoat\TheConsoomer\AmqpStamp;
 use CrazyGoat\TheConsoomer\ConnectionInterface;
+use CrazyGoat\TheConsoomer\ConnectionRetryInterface;
 use CrazyGoat\TheConsoomer\InfrastructureSetupInterface;
 use CrazyGoat\TheConsoomer\Sender;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -448,9 +449,188 @@ class SenderTest extends TestCase
         $sender->send($envelope);
     }
 
+    public function testSendWithConfirmTimeoutEnablesConfirms(): void
+    {
+        $options = ['exchange' => 'test_exchange', 'confirm_timeout' => 5];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $channel->expects($this->once())->method('confirmSelect');
+        $channel->expects($this->once())->method('waitForConfirm')->with(5.0);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('getChannel')
+            ->willReturn($channel);
+
+        $envelope = new Envelope(new \stdClass());
+
+        $this->serializer
+            ->method('encode')
+            ->willReturn(['body' => 'test', 'headers' => []]);
+
+        $this->exchange
+            ->expects($this->once())
+            ->method('publish');
+
+        $this->connection
+            ->expects($this->once())
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('updateActivity');
+
+        $sender = $this->createSender($options);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithoutConfirmTimeoutDoesNotEnableConfirms(): void
+    {
+        $options = ['exchange' => 'test_exchange'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $channel->expects($this->never())->method('confirmSelect');
+        $channel->expects($this->never())->method('waitForConfirm');
+
+        $this->connection
+            ->expects($this->never())
+            ->method('getChannel');
+
+        $envelope = new Envelope(new \stdClass());
+
+        $this->serializer
+            ->method('encode')
+            ->willReturn(['body' => 'test', 'headers' => []]);
+
+        $this->exchange
+            ->expects($this->once())
+            ->method('publish');
+
+        $this->connection
+            ->expects($this->once())
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('updateActivity');
+
+        $sender = $this->createSender($options);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithZeroConfirmTimeoutDoesNotEnableConfirms(): void
+    {
+        $options = ['exchange' => 'test_exchange', 'confirm_timeout' => 0];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $channel->expects($this->never())->method('confirmSelect');
+        $channel->expects($this->never())->method('waitForConfirm');
+
+        $this->connection
+            ->expects($this->never())
+            ->method('getChannel');
+
+        $envelope = new Envelope(new \stdClass());
+
+        $this->serializer
+            ->method('encode')
+            ->willReturn(['body' => 'test', 'headers' => []]);
+
+        $this->exchange
+            ->expects($this->once())
+            ->method('publish');
+
+        $this->connection
+            ->expects($this->once())
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->connection
+            ->expects($this->once())
+            ->method('updateActivity');
+
+        $sender = $this->createSender($options);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithConfirmTimeoutAndRetryCallsConfirmEachAttempt(): void
+    {
+        $options = ['exchange' => 'test_exchange', 'confirm_timeout' => 5, 'retry' => true];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $channel->expects($this->exactly(2))->method('confirmSelect');
+        $channel->expects($this->exactly(2))->method('waitForConfirm')->with(5.0);
+
+        $this->connection
+            ->method('getChannel')
+            ->willReturn($channel);
+
+        $this->connection
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->connection
+            ->expects($this->exactly(2))
+            ->method('updateActivity');
+
+        $envelope = new Envelope(new \stdClass());
+
+        $retry = $this->createMock(ConnectionRetryInterface::class);
+        $retry
+            ->method('withRetry')
+            ->willReturnCallback(function (callable $callback): void {
+                $callback();
+                $callback();
+            });
+
+        $this->serializer
+            ->method('encode')
+            ->willReturn(['body' => 'test', 'headers' => []]);
+
+        $this->exchange
+            ->expects($this->exactly(2))
+            ->method('publish');
+
+        $sender = $this->createSenderWithRetry($options, $retry);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithNegativeConfirmTimeoutThrowsException(): void
+    {
+        $options = ['exchange' => 'test_exchange', 'confirm_timeout' => -1];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('confirm_timeout must be a non-negative value');
+
+        new Sender($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+    }
+
+    public function testSendWithNegativeFloatConfirmTimeoutThrowsException(): void
+    {
+        $options = ['exchange' => 'test_exchange', 'confirm_timeout' => -0.5];
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('confirm_timeout must be a non-negative value');
+
+        new Sender($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+    }
+
     private function createSender(array $options): Sender
     {
         $sender = new Sender($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $reflection = new \ReflectionClass(Sender::class);
+        $exchangeProperty = $reflection->getProperty('exchange');
+        $exchangeProperty->setValue($sender, $this->exchange);
+
+        return $sender;
+    }
+
+    private function createSenderWithRetry(array $options, ConnectionRetryInterface $retry): Sender
+    {
+        $sender = new Sender($this->factory, $this->connection, $this->serializer, $options, $this->setup, $retry);
 
         $reflection = new \ReflectionClass(Sender::class);
         $exchangeProperty = $reflection->getProperty('exchange');


### PR DESCRIPTION
## Description

Adds publisher confirms support to ensure messages are not lost during publish.

### Changes

- **Sender**: When `confirm_timeout > 0`, calls `confirmSelect()` before publish and `waitForConfirm()` after publish
- **Validation**: `confirm_timeout` must be non-negative (0 = disabled)
- **DSN usage**: `amqp-consoomer://host/vhost/exchange?confirm_timeout=5`
- **Backward compatible**: disabled by default, no breaking changes
- **Unit tests**: 6 new tests covering confirm mode, timeout, zero/negative values, and retry integration
- **E2E tests**: 3 new tests with real RabbitMQ

### Usage

```php
 = 'amqp-consoomer://guest:guest@localhost:5672/%2f/my_exchange?confirm_timeout=5';
```

When confirm_timeout is set, the sender waits up to the specified seconds for broker confirmation. If the broker does not confirm within the timeout, an `AMQPQueueException` is thrown.

Closes #27