### PR TITLE
#24 Message Priority

### DIFF
--- a/src/AmqpPriorityStamp.php
+++ b/src/AmqpPriorityStamp.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer;
+
+use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
+
+/**
+ * Stamp that holds explicit message priority (0-9) for AMQP publish.
+ *
+ * Higher priority messages are processed before lower priority ones.
+ * Requires the queue to be configured with x-max-priority argument.
+ */
+final readonly class AmqpPriorityStamp implements NonSendableStampInterface
+{
+    public function __construct(
+        private int $priority,
+    ) {
+        if ($priority < 0 || $priority > 9) {
+            throw new \InvalidArgumentException(sprintf('Priority must be between 0 and 9, got %d', $priority));
+        }
+    }
+
+    public function getPriority(): int
+    {
+        return $this->priority;
+    }
+}

--- a/src/Sender.php
+++ b/src/Sender.php
@@ -107,6 +107,11 @@ final class Sender implements SenderInterface
         $flags = $stamp?->getFlags() ?? \AMQP_NOPARAM;
         $attributes = array_merge($data['headers'] ?? [], $stamp?->getAttributes() ?? []);
 
+        $priorityStamp = $envelope->last(AmqpPriorityStamp::class);
+        if ($priorityStamp instanceof AmqpPriorityStamp) {
+            $attributes['priority'] = $priorityStamp->getPriority();
+        }
+
         $publishCallback = function () use ($data, $routingKey, $flags, $attributes): void {
             if ($this->confirmTimeout > 0.0) {
                 $channel = $this->connection->getChannel();

--- a/tests/Unit/AmqpPriorityStampTest.php
+++ b/tests/Unit/AmqpPriorityStampTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace CrazyGoat\TheConsoomer\Tests\Unit;
+
+use CrazyGoat\TheConsoomer\AmqpPriorityStamp;
+use PHPUnit\Framework\TestCase;
+
+class AmqpPriorityStampTest extends TestCase
+{
+    public function testConstructorWithPriority(): void
+    {
+        $stamp = new AmqpPriorityStamp(5);
+
+        $this->assertSame(5, $stamp->getPriority());
+    }
+
+    public function testIsNonSendable(): void
+    {
+        $stamp = new AmqpPriorityStamp(0);
+
+        $this->assertInstanceOf(\Symfony\Component\Messenger\Stamp\NonSendableStampInterface::class, $stamp);
+    }
+
+    public function testAllowsZeroPriority(): void
+    {
+        $stamp = new AmqpPriorityStamp(0);
+
+        $this->assertSame(0, $stamp->getPriority());
+    }
+
+    public function testAllowsMaxPriority(): void
+    {
+        $stamp = new AmqpPriorityStamp(9);
+
+        $this->assertSame(9, $stamp->getPriority());
+    }
+
+    /** @dataProvider invalidPriorityProvider */
+    public function testInvalidPriorityThrowsException(int $priority): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Priority must be between 0 and 9');
+
+        new AmqpPriorityStamp($priority);
+    }
+
+    /** @return array<string, array{int}> */
+    public static function invalidPriorityProvider(): array
+    {
+        return [
+            'negative' => [-1],
+            'too high' => [10],
+        ];
+    }
+}

--- a/tests/Unit/SenderTest.php
+++ b/tests/Unit/SenderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\AmqpFactory;
+use CrazyGoat\TheConsoomer\AmqpPriorityStamp;
 use CrazyGoat\TheConsoomer\AmqpStamp;
 use CrazyGoat\TheConsoomer\ConnectionInterface;
 use CrazyGoat\TheConsoomer\ConnectionRetryInterface;
@@ -615,6 +616,93 @@ class SenderTest extends TestCase
         $this->expectExceptionMessage('confirm_timeout must be a non-negative value');
 
         new Sender($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+    }
+
+    public function testSendWithPriorityStampAddsPriorityToAttributes(): void
+    {
+        $options = ['exchange' => 'test_exchange'];
+        $priorityStamp = new AmqpPriorityStamp(7);
+        $envelope = new Envelope(new \stdClass(), [$priorityStamp]);
+
+        $this->serializer
+            ->method('encode')
+            ->willReturn(['body' => 'test', 'headers' => []]);
+
+        $this->exchange
+            ->expects($this->once())
+            ->method('publish')
+            ->with(
+                'test',
+                '',
+                \AMQP_NOPARAM,
+                ['priority' => 7],
+            );
+
+        $this->connection
+            ->expects($this->once())
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $sender = $this->createSender($options);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithPriorityStampOverridesAmqpStampPriority(): void
+    {
+        $options = ['exchange' => 'test_exchange'];
+        $amqpStamp = new AmqpStamp('key', \AMQP_NOPARAM, ['priority' => 2]);
+        $priorityStamp = new AmqpPriorityStamp(8);
+        $envelope = new Envelope(new \stdClass(), [$amqpStamp, $priorityStamp]);
+
+        $this->serializer
+            ->method('encode')
+            ->willReturn(['body' => 'test', 'headers' => []]);
+
+        $this->exchange
+            ->expects($this->once())
+            ->method('publish')
+            ->with(
+                'test',
+                'key',
+                \AMQP_NOPARAM,
+                ['priority' => 8],
+            );
+
+        $this->connection
+            ->expects($this->once())
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $sender = $this->createSender($options);
+        $sender->send($envelope);
+    }
+
+    public function testSendWithoutPriorityStampDoesNotAddPriority(): void
+    {
+        $options = ['exchange' => 'test_exchange'];
+        $envelope = new Envelope(new \stdClass());
+
+        $this->serializer
+            ->method('encode')
+            ->willReturn(['body' => 'test', 'headers' => []]);
+
+        $this->exchange
+            ->expects($this->once())
+            ->method('publish')
+            ->with(
+                'test',
+                '',
+                \AMQP_NOPARAM,
+                [],
+            );
+
+        $this->connection
+            ->expects($this->once())
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $sender = $this->createSender($options);
+        $sender->send($envelope);
     }
 
     private function createSender(array $options): Sender


### PR DESCRIPTION
## Summary

Adds `AmqpPriorityStamp` for setting explicit message priority (0-9) when publishing messages via the AMQP transport.

## Changes

- **New:** `src/AmqpPriorityStamp.php` — Stamp class that holds message priority value with validation (0-9 range)
- **Modified:** `src/Sender.php` — Extracts `AmqpPriorityStamp` from envelope and sets `priority` in publish attributes
- **New:** `tests/Unit/AmqpPriorityStampTest.php` — Unit tests for the stamp
- **Modified:** `tests/Unit/SenderTest.php` — Integration tests verifying priority stamp handling

## Priority resolution

`AmqpPriorityStamp` takes precedence over `priority` values embedded in `AmqpStamp` attributes, giving users an explicit, dedicated API for priority control.

## Usage

```php
use Symfony\Component\Messenger\Envelope;
use CrazyGoat\TheConsoomer\AmqpPriorityStamp;

 = new Envelope(, [
    new AmqpPriorityStamp(7),
]);
->send();
```

## Verification

- ✅ Unit tests pass (258 tests)
- ✅ PHP CS Fixer — clean
- ✅ PHPStan level 3 — no errors