### PR TITLE
#35 Support Multiple Queues and Exchange Types in Auto-Setup

### DIFF
--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -19,7 +19,8 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
     /**
      * @param array{
      *     exchange: string,
-     *     queue: string,
+     *     queue?: string,
+     *     queues?: array<string, array{binding_keys?: list<string>, binding_arguments?: array<string, mixed>, arguments?: array<string, mixed>}>,
      *     exchange_type?: string,
      *     routing_key?: string,
      *     queue_arguments?: array<string, mixed>,
@@ -35,8 +36,16 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         private readonly ConnectionInterface $connection,
         private readonly array $options,
     ) {
-        if (!isset($options['exchange']) || !isset($options['queue'])) {
-            throw new \InvalidArgumentException('exchange and queue options are required');
+        if (!isset($options['exchange'])) {
+            throw new \InvalidArgumentException('exchange option is required');
+        }
+
+        if (!isset($options['queue']) && !isset($options['queues'])) {
+            throw new \InvalidArgumentException('either queue or queues option is required');
+        }
+
+        if (isset($options['queues'])) {
+            $this->validateQueues($options['queues']);
         }
 
         if (isset($options['exchange_bindings'])) {
@@ -70,6 +79,31 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         $exchange->setFlags(\AMQP_DURABLE | ($this->options['exchange_flags'] ?? 0));
         $exchange->declareExchange();
 
+        $this->setupQueues($channel, $exchange);
+        $this->setupExchangeBindings($exchange);
+        $this->setupRetryQueue();
+
+        $this->setupPerformed = true;
+    }
+
+    /**
+     * Creates and binds queues based on configuration.
+     *
+     * Supports both single queue (via 'queue' option) and multiple queues
+     * (via 'queues' option). When 'queues' is provided, each queue can have
+     * its own binding_keys, binding_arguments, and arguments.
+     */
+    private function setupQueues(\AMQPChannel $channel, \AMQPExchange $exchange): void
+    {
+        if (isset($this->options['queues'])) {
+            $this->setupMultipleQueues($channel, $exchange);
+        } else {
+            $this->setupSingleQueue($channel, $exchange);
+        }
+    }
+
+    private function setupSingleQueue(\AMQPChannel $channel, \AMQPExchange $exchange): void
+    {
         $queue = $this->factory->createQueue($channel);
         $queue->setName($this->options['queue']);
         $queue->setFlags(\AMQP_DURABLE | ($this->options['queue_flags'] ?? 0));
@@ -80,11 +114,71 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
 
         $routingKey = $this->options['routing_key'] ?? '';
         $queue->bind($exchange->getName(), $routingKey);
+    }
 
-        $this->setupExchangeBindings($exchange);
-        $this->setupRetryQueue();
+    private function setupMultipleQueues(\AMQPChannel $channel, \AMQPExchange $exchange): void
+    {
+        foreach ($this->options['queues'] as $queueName => $queueConfig) {
+            $queue = $this->factory->createQueue($channel);
+            $queue->setName($queueName);
+            $queue->setFlags(\AMQP_DURABLE | ($this->options['queue_flags'] ?? 0));
 
-        $this->setupPerformed = true;
+            $queueArgs = $queueConfig['arguments'] ?? $this->options['queue_arguments'] ?? null;
+            if ($queueArgs !== null) {
+                $queue->setArguments($queueArgs);
+            }
+            $queue->declareQueue();
+
+            $bindingKeys = $queueConfig['binding_keys'] ?? [''];
+            $bindingArguments = $queueConfig['binding_arguments'] ?? [];
+            foreach ($bindingKeys as $bindingKey) {
+                $queue->bind($exchange->getName(), $bindingKey, $bindingArguments);
+            }
+        }
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private function validateQueues(mixed $queues): void
+    {
+        if (!is_array($queues)) {
+            throw new \InvalidArgumentException('queues option must be an array');
+        }
+
+        if ($queues === []) {
+            throw new \InvalidArgumentException('queues option must not be empty');
+        }
+
+        foreach ($queues as $name => $config) {
+            if (!is_string($name) || $name === '') {
+                throw new \InvalidArgumentException('Each queue name must be a non-empty string');
+            }
+
+            if (!is_array($config)) {
+                throw new \InvalidArgumentException(sprintf('queues[%s] must be an array', $name));
+            }
+
+            if (isset($config['binding_keys'])) {
+                if (!is_array($config['binding_keys'])) {
+                    throw new \InvalidArgumentException(sprintf('queues[%s].binding_keys must be an array', $name));
+                }
+
+                foreach ($config['binding_keys'] as $keyIndex => $key) {
+                    if (!is_string($key)) {
+                        throw new \InvalidArgumentException(sprintf('queues[%s].binding_keys[%d] must be a string', $name, $keyIndex));
+                    }
+                }
+            }
+
+            if (isset($config['binding_arguments']) && !is_array($config['binding_arguments'])) {
+                throw new \InvalidArgumentException(sprintf('queues[%s].binding_arguments must be an array', $name));
+            }
+
+            if (isset($config['arguments']) && !is_array($config['arguments'])) {
+                throw new \InvalidArgumentException(sprintf('queues[%s].arguments must be an array', $name));
+            }
+        }
     }
 
     private function setupExchangeBindings(\AMQPExchange $exchange): void
@@ -103,6 +197,10 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
 
     private function setupRetryQueue(): void
     {
+        if (!isset($this->options['queue'])) {
+            return;
+        }
+
         $retryExchangeName = $this->options['retry_exchange'] ?? $this->options['exchange'] . '_retry';
         $routingKey = $this->options['routing_key'] ?? '';
         $retryQueueName = $this->options['queue'] . '_retry';

--- a/tests/Unit/InfrastructureSetupTest.php
+++ b/tests/Unit/InfrastructureSetupTest.php
@@ -363,4 +363,429 @@ class InfrastructureSetupTest extends TestCase
         $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
         $setup->setup();
     }
+
+    public function testSetupWithMultipleQueues(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue, $this->createMock(\AMQPQueue::class));
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+
+        $this->exchange->expects($this->once())->method('setName')->with('test_exchange');
+        $this->exchange->expects($this->once())->method('setType')->with(AMQP_EX_TYPE_DIRECT);
+        $this->exchange->expects($this->once())->method('declareExchange');
+
+        $this->queue->expects($this->once())->method('setName')->with('queue_a');
+        $this->queue->expects($this->once())->method('declareQueue');
+        $this->queue->expects($this->once())->method('bind')->with('test_exchange', '');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'queue_a' => [],
+                'queue_b' => [],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesAndBindingKeys(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+        $queueB = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $bindCallCount = 0;
+        $queueA->expects($this->exactly(2))->method('bind')
+            ->willReturnCallback(function ($exchange, $key, $args = []) use (&$bindCallCount): void {
+                if ($bindCallCount === 0) {
+                    $this->assertSame('test_exchange', $exchange);
+                    $this->assertSame('order.created', $key);
+                } elseif ($bindCallCount === 1) {
+                    $this->assertSame('test_exchange', $exchange);
+                    $this->assertSame('order.updated', $key);
+                }
+                $bindCallCount++;
+            });
+
+        $queueB->expects($this->once())->method('setName')->with('notifications');
+        $queueB->expects($this->once())->method('declareQueue');
+        $queueB->expects($this->once())->method('bind')->with('test_exchange', 'notification.*');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'orders' => [
+                    'binding_keys' => ['order.created', 'order.updated'],
+                ],
+                'notifications' => [
+                    'binding_keys' => ['notification.*'],
+                ],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesAndBindingArguments(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->expects($this->once())->method('setName')->with('my_queue');
+        $queueA->expects($this->once())->method('declareQueue');
+        $queueA->expects($this->once())->method('bind')
+            ->with('test_exchange', 'my.key', ['x-match' => 'any']);
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'my_queue' => [
+                    'binding_keys' => ['my.key'],
+                    'binding_arguments' => ['x-match' => 'any'],
+                ],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesAndPerQueueArguments(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->expects($this->once())->method('setName')->with('priority_queue');
+        $queueA->expects($this->once())->method('setArguments')->with(['x-max-priority' => 10]);
+        $queueA->expects($this->once())->method('declareQueue');
+        $queueA->expects($this->once())->method('bind')->with('test_exchange', '');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'priority_queue' => [
+                    'binding_keys' => [''],
+                    'arguments' => ['x-max-priority' => 10],
+                ],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testConstructorThrowsWhenNeitherQueueNorQueuesProvided(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('either queue or queues option is required');
+
+        new InfrastructureSetup($this->factory, $this->connection, ['exchange' => 'test_exchange']);
+    }
+
+    public function testConstructorThrowsWhenQueuesIsNotAnArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('queues option must be an array');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => 'invalid',
+        ]);
+    }
+
+    public function testConstructorThrowsWhenQueuesIsEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('queues option must not be empty');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => [],
+        ]);
+    }
+
+    public function testConstructorThrowsWhenQueueNameIsEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Each queue name must be a non-empty string');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => ['' => []],
+        ]);
+    }
+
+    public function testConstructorThrowsWhenQueueConfigIsNotArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('queues[bad] must be an array');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => ['bad' => 'not_an_array'],
+        ]);
+    }
+
+    public function testConstructorThrowsWhenBindingKeysIsNotArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('queues[q].binding_keys must be an array');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'q' => ['binding_keys' => 'invalid'],
+            ],
+        ]);
+    }
+
+    public function testConstructorThrowsWhenBindingKeyIsNotString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('queues[q].binding_keys[0] must be a string');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'q' => ['binding_keys' => [42]],
+            ],
+        ]);
+    }
+
+    public function testConstructorThrowsWhenBindingArgumentsIsNotArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('queues[q].binding_arguments must be an array');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'q' => ['binding_arguments' => 'invalid'],
+            ],
+        ]);
+    }
+
+    public function testConstructorThrowsWhenQueueArgumentsIsNotArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('queues[q].arguments must be an array');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'q' => ['arguments' => 'invalid'],
+            ],
+        ]);
+    }
+
+    public function testSetupIdempotentWithMultipleQueues(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->expects($this->once())->method('setName')->with('my_queue');
+        $queueA->expects($this->once())->method('declareQueue');
+        $queueA->expects($this->once())->method('bind');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'my_queue' => [],
+            ],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesUsesGlobalQueueArguments(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->expects($this->once())->method('setName')->with('my_queue');
+        $queueA->expects($this->once())->method('setArguments')->with(['x-message-ttl' => 60000]);
+        $queueA->expects($this->once())->method('declareQueue');
+        $queueA->expects($this->once())->method('bind')->with('test_exchange', '');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'my_queue' => [],
+            ],
+            'queue_arguments' => ['x-message-ttl' => 60000],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesPerQueueArgumentsOverrideGlobal(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        // Per-queue arguments should override global queue_arguments
+        $queueA->expects($this->once())->method('setName')->with('my_queue');
+        $queueA->expects($this->once())->method('setArguments')->with(['x-max-priority' => 10]);
+        $queueA->expects($this->once())->method('declareQueue');
+        $queueA->expects($this->once())->method('bind')->with('test_exchange', '');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'my_queue' => [
+                    'arguments' => ['x-max-priority' => 10],
+                ],
+            ],
+            'queue_arguments' => ['x-message-ttl' => 60000],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
 }


### PR DESCRIPTION
Adds support for the queues option in InfrastructureSetup, enabling declaration of multiple queues with per-queue binding keys, binding arguments, and queue arguments.

Changes:
- queues option: array of queue configs keyed by queue name
- Each queue supports: binding_keys, binding_arguments, arguments
- Backward compatible: single queue option still works
- Retry queue setup is skipped when using multiple queues
- Full validation for queues option structure
- 20+ new unit tests covering all scenarios