### PR TITLE
feat: add binding_keys and binding_arguments support for single queue

### DIFF
--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -23,6 +23,8 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
      *     queues?: array<string, array{binding_keys?: list<string>, binding_arguments?: array<string, mixed>, arguments?: array<string, mixed>}>,
      *     exchange_type?: string,
      *     routing_key?: string,
+     *     binding_keys?: list<string>,
+     *     binding_arguments?: array<string, mixed>,
      *     queue_arguments?: array<string, mixed>,
      *     exchange_flags?: int,
      *     queue_flags?: int,
@@ -50,6 +52,14 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
 
         if (isset($options['exchange_bindings'])) {
             $this->validateExchangeBindings($options['exchange_bindings']);
+        }
+
+        if (isset($options['binding_keys'])) {
+            $this->validateBindingKeys($options['binding_keys']);
+        }
+
+        if (isset($options['binding_arguments']) && !is_array($options['binding_arguments'])) {
+            throw new \InvalidArgumentException('binding_arguments must be an array');
         }
     }
 
@@ -112,8 +122,11 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         }
         $queue->declareQueue();
 
-        $routingKey = $this->options['routing_key'] ?? '';
-        $queue->bind($exchange->getName(), $routingKey);
+        $bindingKeys = $this->options['binding_keys'] ?? [$this->options['routing_key'] ?? ''];
+        $bindingArguments = $this->options['binding_arguments'] ?? [];
+        foreach ($bindingKeys as $bindingKey) {
+            $queue->bind($exchange->getName(), $bindingKey, $bindingArguments);
+        }
     }
 
     private function setupMultipleQueues(\AMQPChannel $channel, \AMQPExchange $exchange): void
@@ -218,6 +231,26 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         ]);
         $retryQueue->declareQueue();
         $retryQueue->bind($retryExchangeName, $routingKey . '_retry');
+    }
+
+    /**
+     * @throws \InvalidArgumentException
+     */
+    private function validateBindingKeys(mixed $bindingKeys): void
+    {
+        if (!is_array($bindingKeys)) {
+            throw new \InvalidArgumentException('binding_keys must be an array');
+        }
+
+        if ($bindingKeys === []) {
+            throw new \InvalidArgumentException('binding_keys must not be empty');
+        }
+
+        foreach ($bindingKeys as $index => $key) {
+            if (!is_string($key)) {
+                throw new \InvalidArgumentException(sprintf('binding_keys[%d] must be a string', $index));
+            }
+        }
     }
 
     /**

--- a/tests/Unit/InfrastructureSetupTest.php
+++ b/tests/Unit/InfrastructureSetupTest.php
@@ -743,6 +743,210 @@ class InfrastructureSetupTest extends TestCase
         $setup->setup();
     }
 
+    public function testSetupWithSingleQueueAndBindingKeys(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $bindCallCount = 0;
+        $this->queue->expects($this->exactly(2))->method('bind')
+            ->willReturnCallback(function ($exchange, $key, $args = []) use (&$bindCallCount): void {
+                if ($bindCallCount === 0) {
+                    $this->assertSame('test_exchange', $exchange);
+                    $this->assertSame('order.created', $key);
+                } elseif ($bindCallCount === 1) {
+                    $this->assertSame('test_exchange', $exchange);
+                    $this->assertSame('order.updated', $key);
+                }
+                $bindCallCount++;
+            });
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'binding_keys' => ['order.created', 'order.updated'],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithSingleQueueAndBindingArguments(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $this->queue->expects($this->once())->method('bind')
+            ->with('test_exchange', 'my.key', ['x-match' => 'any']);
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'binding_keys' => ['my.key'],
+            'binding_arguments' => ['x-match' => 'any'],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testConstructorThrowsWhenTopLevelBindingKeysIsNotArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('binding_keys must be an array');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'binding_keys' => 'invalid',
+        ]);
+    }
+
+    public function testConstructorThrowsWhenTopLevelBindingKeyIsNotString(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('binding_keys[0] must be a string');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'binding_keys' => [42],
+        ]);
+    }
+
+    public function testConstructorThrowsWhenTopLevelBindingArgumentsIsNotArray(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('binding_arguments must be an array');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'binding_arguments' => 'invalid',
+        ]);
+    }
+
+    public function testConstructorThrowsWhenTopLevelBindingKeysIsEmpty(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('binding_keys must not be empty');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'binding_keys' => [],
+        ]);
+    }
+
+    public function testSetupWithSingleQueueFallsBackToRoutingKeyWhenNoBindingKeys(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $this->queue->expects($this->once())->method('bind')
+            ->with('test_exchange', 'fallback_key');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'routing_key' => 'fallback_key',
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithSingleQueuePassesBindingArgumentsWithRoutingKeyFallback(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $this->queue->expects($this->once())->method('bind')
+            ->with('test_exchange', 'routing_key_val', ['x-match' => 'all']);
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'routing_key' => 'routing_key_val',
+            'binding_arguments' => ['x-match' => 'all'],
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
     public function testSetupWithMultipleQueuesPerQueueArgumentsOverrideGlobal(): void
     {
         $this->connection->method('getChannel')->willReturn($this->channel);


### PR DESCRIPTION
## Description

Adds `binding_keys` and `binding_arguments` option support to the single queue path in `InfrastructureSetup`, enabling:

1. Multiple routing keys for a single queue via `binding_keys` option
2. Binding arguments (e.g., `x-match` for headers exchanges) via `binding_arguments` option

## Backward Compatibility

Fully backward compatible. When `binding_keys` is not set, the existing `routing_key` fallback is preserved.

## Changes

- Added `binding_keys` and `binding_arguments` to the @param type
- Updated `setupSingleQueue()` to accept multiple binding keys with optional arguments
- Added `validateBindingKeys()` with non-empty and type validation
- Added validation for `binding_arguments` to be an array
- Added 8 new tests covering all validation and functional scenarios

Closes #21