### PR TITLE
Validate exchange/queue flags and add durable option

### DIFF
--- a/src/AmqpTransportFactory.php
+++ b/src/AmqpTransportFactory.php
@@ -88,6 +88,7 @@ class AmqpTransportFactory implements TransportFactoryInterface
      *     exchange_flags?: int,
      *     queue_flags?: int,
      *     persistent?: bool,
+     *     durable?: bool,
      * } $options
      * @param SerializerInterface  $serializer Message serializer
      * @param AmqpFactoryInterface|null $factory    AMQP factory (optional)

--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -50,6 +50,7 @@ final class DsnParser
      *     exchange_flags?: int,
      *     queue_flags?: int,
      *     persistent?: bool,
+     *     durable?: bool,
      * }
      */
     public function parse(string $dsn): array

--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -14,6 +14,9 @@ use CrazyGoat\TheConsoomer\Enum\ExchangeType;
  */
 final class InfrastructureSetup implements InfrastructureSetupInterface
 {
+    private const FORBIDDEN_FLAGS = \AMQP_EXCLUSIVE | \AMQP_AUTODELETE;
+    private const ALLOWED_OPTION_KEYS = ['exchange_flags', 'queue_flags'];
+
     private bool $setupPerformed = false;
 
     /**
@@ -31,6 +34,7 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
      *     exchange_bindings?: array<array{target: string, routing_keys?: list<string>}>,
      *     retry_exchange?: string,
      *     retry_queue_arguments?: array<string, mixed>,
+     *     durable?: bool,
      * } $options
      */
     public function __construct(
@@ -61,6 +65,16 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         if (isset($options['binding_arguments']) && !is_array($options['binding_arguments'])) {
             throw new \InvalidArgumentException('binding_arguments must be an array');
         }
+
+        foreach (self::ALLOWED_OPTION_KEYS as $key) {
+            if (isset($options[$key]) && is_int($options[$key]) && ($options[$key] & self::FORBIDDEN_FLAGS) !== 0) {
+                throw new \InvalidArgumentException(sprintf(
+                    '%s must not contain AMQP_EXCLUSIVE or AMQP_AUTODELETE flags (got %d)',
+                    $key,
+                    $options[$key],
+                ));
+            }
+        }
     }
 
     /**
@@ -86,7 +100,7 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
             default => \AMQP_EX_TYPE_DIRECT,
         };
         $exchange->setType($type);
-        $exchange->setFlags(\AMQP_DURABLE | ($this->options['exchange_flags'] ?? 0));
+        $exchange->setFlags($this->resolveFlags('exchange_flags'));
         $exchange->declareExchange();
 
         $this->setupQueues($channel, $exchange);
@@ -116,7 +130,7 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
     {
         $queue = $this->factory->createQueue($channel);
         $queue->setName($this->options['queue']);
-        $queue->setFlags(\AMQP_DURABLE | ($this->options['queue_flags'] ?? 0));
+        $queue->setFlags($this->resolveFlags('queue_flags'));
         if (isset($this->options['queue_arguments'])) {
             $queue->setArguments($this->options['queue_arguments']);
         }
@@ -134,7 +148,7 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         foreach ($this->options['queues'] as $queueName => $queueConfig) {
             $queue = $this->factory->createQueue($channel);
             $queue->setName($queueName);
-            $queue->setFlags(\AMQP_DURABLE | ($this->options['queue_flags'] ?? 0));
+            $queue->setFlags($this->resolveFlags('queue_flags'));
 
             $queueArgs = $queueConfig['arguments'] ?? $this->options['queue_arguments'] ?? null;
             if ($queueArgs !== null) {
@@ -206,6 +220,15 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
                 $exchange->bind($target, $routingKey);
             }
         }
+    }
+
+    private function resolveFlags(string $optionName): int
+    {
+        $flags = (int) ($this->options[$optionName] ?? 0);
+        if ($this->options['durable'] ?? true) {
+            $flags |= \AMQP_DURABLE;
+        }
+        return $flags;
     }
 
     private function setupRetryQueue(): void

--- a/tests/Unit/InfrastructureSetupTest.php
+++ b/tests/Unit/InfrastructureSetupTest.php
@@ -947,6 +947,309 @@ class InfrastructureSetupTest extends TestCase
         $setup->setup();
     }
 
+    public function testConstructorRejectsExchangeFlagsWithExclusive(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain AMQP_EXCLUSIVE or AMQP_AUTODELETE flags');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_flags' => \AMQP_EXCLUSIVE,
+        ]);
+    }
+
+    public function testConstructorRejectsExchangeFlagsWithAutoDelete(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain AMQP_EXCLUSIVE or AMQP_AUTODELETE flags');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_flags' => \AMQP_AUTODELETE,
+        ]);
+    }
+
+    public function testConstructorRejectsQueueFlagsWithExclusive(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain AMQP_EXCLUSIVE or AMQP_AUTODELETE flags');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'queue_flags' => \AMQP_EXCLUSIVE,
+        ]);
+    }
+
+    public function testConstructorRejectsQueueFlagsWithAutoDelete(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain AMQP_EXCLUSIVE or AMQP_AUTODELETE flags');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'queue_flags' => \AMQP_AUTODELETE,
+        ]);
+    }
+
+    public function testConstructorRejectsFlagsWithCombinedForbiddenBits(): void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('must not contain AMQP_EXCLUSIVE or AMQP_AUTODELETE flags');
+
+        new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_flags' => \AMQP_EXCLUSIVE | \AMQP_AUTODELETE,
+        ]);
+    }
+
+    public function testConstructorAcceptsDurableOnlyFlag(): void
+    {
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_flags' => \AMQP_DURABLE,
+        ]);
+
+        $this->assertInstanceOf(InfrastructureSetup::class, $setup);
+    }
+
+    public function testConstructorAcceptsZeroFlags(): void
+    {
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'exchange_flags' => 0,
+        ]);
+
+        $this->assertInstanceOf(InfrastructureSetup::class, $setup);
+    }
+
+    public function testConstructorAcceptsNoFlags(): void
+    {
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+        ]);
+
+        $this->assertInstanceOf(InfrastructureSetup::class, $setup);
+    }
+
+    public function testSetupAppliesDurableByDefault(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        $this->exchange->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+        $this->exchange->method('getName')->willReturn('test_exchange');
+
+        $this->queue->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $this->queue->method('setName');
+        $this->queue->method('declareQueue');
+        $this->queue->method('bind');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+        ]);
+
+        $setup->setup();
+    }
+
+    public function testSetupWithoutDurableDoesNotSetDurableFlag(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        // Without AMQP_DURABLE (2), the flag should be 0 (AMQP_NOPARAM)
+        $this->exchange->expects($this->once())->method('setFlags')->with(0);
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+        $this->exchange->method('getName')->willReturn('test_exchange');
+
+        $this->queue->expects($this->once())->method('setFlags')->with(0);
+        $this->queue->method('setName');
+        $this->queue->method('declareQueue');
+        $this->queue->method('bind');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'durable' => false,
+        ]);
+
+        $setup->setup();
+    }
+
+    public function testSetupWithDurableFalseAndCustomQueueFlags(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        $this->exchange->expects($this->once())->method('setFlags')->with(0);
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+        $this->exchange->method('getName')->willReturn('test_exchange');
+
+        $this->queue->expects($this->once())->method('setFlags')->with(0);
+        $this->queue->method('setName');
+        $this->queue->method('declareQueue');
+        $this->queue->method('bind');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'durable' => false,
+            'exchange_flags' => 0,
+            'queue_flags' => 0,
+        ]);
+
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesAppliesQueueFlags(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+        $queueB = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $queueB->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $queueA->method('setName');
+        $queueB->method('setName');
+        $queueA->method('declareQueue');
+        $queueB->method('declareQueue');
+        $queueA->method('bind');
+        $queueB->method('bind');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'queue_a' => [],
+                'queue_b' => [],
+            ],
+        ]);
+
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesAndDurableFalse(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+        $queueB = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue);
+
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->expects($this->once())->method('setFlags')->with(0);
+        $queueB->expects($this->once())->method('setFlags')->with(0);
+        $queueA->method('setName');
+        $queueB->method('setName');
+        $queueA->method('declareQueue');
+        $queueB->method('declareQueue');
+        $queueA->method('bind');
+        $queueB->method('bind');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->method('declareQueue');
+        $this->retryQueue->method('bind');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queues' => [
+                'queue_a' => [],
+                'queue_b' => [],
+            ],
+            'durable' => false,
+        ]);
+
+        $setup->setup();
+    }
+
     public function testSetupWithMultipleQueuesPerQueueArgumentsOverrideGlobal(): void
     {
         $this->connection->method('getChannel')->willReturn($this->channel);


### PR DESCRIPTION
Closes #233

## Summary
- Reject forbidden flags (`AMQP_EXCLUSIVE`, `AMQP_AUTODELETE`) in `exchange_flags` and `queue_flags` options
- Add `durable` option (default `true` for BC) — when `false`, `AMQP_DURABLE` is not OR'd into flags, allowing transient topology
- Adds `resolveFlags()` helper method to compute final flags based on `durable` option

## Changes
- `src/InfrastructureSetup.php`: flag validation in constructor, `resolveFlags()` method, `durable` option support
- `src/DsnParser.php`: add `durable` to return type docblock
- `src/AmqpTransportFactory.php`: add `durable` to options docblock
- `tests/Unit/InfrastructureSetupTest.php`: 16 new tests covering validation rejection, acceptance, durable default, non-durable, multi-queue