### PR TITLE
fix: coerce ssl_verify to strict bool, reject empty/malformed values

### DIFF
--- a/src/AmqpFactory.php
+++ b/src/AmqpFactory.php
@@ -72,7 +72,8 @@ class AmqpFactory implements AmqpFactoryInterface
      *     ssl_verify?: bool,
      * } $options SSL configuration options
      * @param LoggerInterface|null $logger    Logger instance
-     * @throws \InvalidArgumentException When SSL certificate files are not found or not readable
+     * @throws \InvalidArgumentException When SSL certificate files are not found, not readable,
+     *                                  or ssl_verify is not a valid boolean value
      */
     public function configureSsl(\AMQPConnection $connection, array $options, ?LoggerInterface $logger = null): void
     {

--- a/src/AmqpFactory.php
+++ b/src/AmqpFactory.php
@@ -111,6 +111,19 @@ class AmqpFactory implements AmqpFactoryInterface
         }
 
         $sslVerify = $options['ssl_verify'] ?? true;
+        if (is_string($sslVerify) && $sslVerify === '') {
+            throw new \InvalidArgumentException('ssl_verify must be a boolean value, got empty string');
+        }
+        if (!is_bool($sslVerify)) {
+            $normalized = filter_var($sslVerify, FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE);
+            if ($normalized === null) {
+                throw new \InvalidArgumentException(sprintf(
+                    'ssl_verify must be a boolean value, got "%s"',
+                    get_debug_type($sslVerify),
+                ));
+            }
+            $sslVerify = $normalized;
+        }
         $connection->setVerify($sslVerify);
         $logger?->debug('SSL verify: {verify}', ['verify' => $sslVerify ? 'enabled' : 'disabled']);
 

--- a/src/AmqpFactoryInterface.php
+++ b/src/AmqpFactoryInterface.php
@@ -51,7 +51,8 @@ interface AmqpFactoryInterface
      *     ssl_verify?: bool,
      * } $options SSL configuration options
      * @param LoggerInterface|null $logger Logger instance
-     * @throws \InvalidArgumentException When SSL certificate files are not found or not readable
+     * @throws \InvalidArgumentException When SSL certificate files are not found, not readable,
+     *                                  or ssl_verify is not a valid boolean value
      */
     public function configureSsl(\AMQPConnection $connection, array $options, ?LoggerInterface $logger = null): void;
 

--- a/tests/Unit/AmqpFactoryTest.php
+++ b/tests/Unit/AmqpFactoryTest.php
@@ -131,4 +131,174 @@ class AmqpFactoryTest extends TestCase
             'ssl_cert' => '/path/to/cert.pem',
         ]);
     }
+
+    public function testConfigureSslVerifyDefaultsToTrueWhenNotSet(): void
+    {
+        $factory = new AmqpFactory();
+
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->once())
+            ->method('setVerify')
+            ->with(true);
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyStringTrue(): void
+    {
+        $factory = new AmqpFactory();
+
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->once())
+            ->method('setVerify')
+            ->with(true);
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => 'true',
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyStringFalse(): void
+    {
+        $factory = new AmqpFactory();
+
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->once())
+            ->method('setVerify')
+            ->with(false);
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => 'false',
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyIntOne(): void
+    {
+        $factory = new AmqpFactory();
+
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->once())
+            ->method('setVerify')
+            ->with(true);
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => 1,
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyIntZero(): void
+    {
+        $factory = new AmqpFactory();
+
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->once())
+            ->method('setVerify')
+            ->with(false);
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => 0,
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyEmptyStringThrows(): void
+    {
+        $factory = new AmqpFactory();
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->never())
+            ->method('setVerify');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('ssl_verify must be a boolean');
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => '',
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyInvalidStringThrows(): void
+    {
+        $factory = new AmqpFactory();
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->never())
+            ->method('setVerify');
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('ssl_verify must be a boolean');
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => 'maybe',
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyNumericStringOne(): void
+    {
+        $factory = new AmqpFactory();
+
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->once())
+            ->method('setVerify')
+            ->with(true);
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => '1',
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyNumericStringZero(): void
+    {
+        $factory = new AmqpFactory();
+
+        $connection = $this->createMock(\AMQPConnection::class);
+        $connection->expects($this->once())
+            ->method('setVerify')
+            ->with(false);
+
+        $factory->configureSsl($connection, [
+            'ssl' => true,
+            'ssl_verify' => '0',
+        ]);
+    }
+
+    public function testConfigureSslWithVerifyStringOneTruthyValues(): void
+    {
+        $factory = new AmqpFactory();
+
+        foreach (['on', 'yes'] as $value) {
+            $connection = $this->createMock(\AMQPConnection::class);
+            $connection->expects($this->once())
+                ->method('setVerify')
+                ->with(true);
+
+            $factory->configureSsl($connection, [
+                'ssl' => true,
+                'ssl_verify' => $value,
+            ]);
+        }
+    }
+
+    public function testConfigureSslWithVerifyStringZeroFalsyValues(): void
+    {
+        $factory = new AmqpFactory();
+
+        foreach (['off', 'no'] as $value) {
+            $connection = $this->createMock(\AMQPConnection::class);
+            $connection->expects($this->once())
+                ->method('setVerify')
+                ->with(false);
+
+            $factory->configureSsl($connection, [
+                'ssl' => true,
+                'ssl_verify' => $value,
+            ]);
+        }
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #232

`ssl_verify` is now strictly coerced to boolean `true`/`false` in `AmqpFactory::configureSsl()`. Empty strings and unrecognized values throw `\InvalidArgumentException` instead of silently disabling TLS verification.

### Changes

- **`src/AmqpFactory.php`**: Added explicit boolean coercion via `filter_var(FILTER_VALIDATE_BOOL, FILTER_NULL_ON_FAILURE)`. Empty strings are rejected early since PHP's `FILTER_VALIDATE_BOOL` treats them as falsy, not `null`.
- **`tests/Unit/AmqpFactoryTest.php`**: 11 new test cases covering all coercion paths.

### Before (broken)

| Input | Behavior |
|-------|----------|
| `""` (empty) | `setVerify("")` → falsy → verification silently **off** |
| `"maybe"` | `setVerify("maybe")` → truthy → verification **on** when it shouldn't be |
| `0` (int) | works by coercion but fragile |
| `"false"` | string is truthy → verify on when user said off |

### After

| Input | Behavior |
|-------|----------|
| not set | `true` (unmodified) |
| `true` / `false` | pass through directly |
| `"true"`, `"1"`, `1`, `"on"`, `"yes"` | coerced to `true` |
| `"false"`, `"0"`, `0`, `"off"`, `"no"` | coerced to `false` |
| `""` (empty) | `\InvalidArgumentException` |
| `"maybe"` / any unrecognized | `\InvalidArgumentException` |