### PR TITLE
fix: circuit-breaker elapsed-time now uses monotonic clock (hrtime) instead of wall clock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Fixed
+- Circuit-breaker elapsed-time now uses monotonic clock (`hrtime(true)`) instead of wall-clock `DateTimeImmutable` — prevents NTP backward step from sticking the circuit OPEN (#237)
+  - Added `ClockInterface::monotonic(): float` method backed by `hrtime(true)` in `SystemClock`
+  - `CircuitBreaker::recordFailure()` stores monotonic timestamp for elapsed measurement
+  - `CircuitBreaker::isAvailable()` computes elapsed from monotonic clock — immune to wall-clock corrections
 - Decoupled `max_unacked_messages` into three separate concerns: QoS prefetch, per-`get()` return-batch size, and ack-batch flush threshold (#238)
   - Added `batch_size` option (default: 1) for per-`get()` return-batch size
   - `max_unacked_messages` now controls only QoS prefetch and ack-batch flush threshold

--- a/src/CircuitBreaker.php
+++ b/src/CircuitBreaker.php
@@ -15,12 +15,15 @@ use Psr\Log\LoggerInterface;
  * - CLOSED: Normal operation, requests flow through
  * - OPEN: Circuit tripped, requests blocked until timeout
  * - HALF_OPEN: Testing if service recovered, limited requests allowed
+ *
+ * Elapsed time is measured using a monotonic clock (hrtime) to avoid
+ * issues with wall-clock corrections (NTP backward steps, etc.).
  */
 final class CircuitBreaker
 {
     private int $failureCount = 0;
     private int $successCount = 0;
-    private ?\DateTimeImmutable $lastFailureTime = null;
+    private float $lastFailureMonotonic = 0.0;
     private CircuitState $state = CircuitState::CLOSED;
 
     /**
@@ -68,7 +71,7 @@ final class CircuitBreaker
     public function recordFailure(): void
     {
         $this->failureCount++;
-        $this->lastFailureTime = $this->clock->now();
+        $this->lastFailureMonotonic = $this->clock->monotonic();
 
         if ($this->state === CircuitState::HALF_OPEN) {
             $this->transitionTo(CircuitState::OPEN);
@@ -81,6 +84,9 @@ final class CircuitBreaker
     /**
      * Checks if circuit breaker allows requests.
      *
+     * Uses monotonic clock for elapsed-time measurement so NTP corrections
+     * never extend or shorten the OPEN period artificially.
+     *
      * @return bool True if requests are allowed (CLOSED or HALF_OPEN after timeout)
      */
     public function isAvailable(): bool
@@ -90,10 +96,7 @@ final class CircuitBreaker
         }
 
         if ($this->state === CircuitState::OPEN) {
-            if (!$this->lastFailureTime instanceof \DateTimeImmutable) {
-                return false;
-            }
-            $elapsed = $this->clock->now()->getTimestamp() - $this->lastFailureTime->getTimestamp();
+            $elapsed = $this->clock->monotonic() - $this->lastFailureMonotonic;
             if ($elapsed >= $this->timeout) {
                 $this->transitionTo(CircuitState::HALF_OPEN);
                 $this->successCount = 0;
@@ -121,7 +124,7 @@ final class CircuitBreaker
         $this->failureCount = 0;
         $this->successCount = 0;
         $this->state = CircuitState::CLOSED;
-        $this->lastFailureTime = null;
+        $this->lastFailureMonotonic = 0.0;
     }
 
     /**

--- a/src/Clock/SystemClock.php
+++ b/src/Clock/SystemClock.php
@@ -8,6 +8,9 @@ use CrazyGoat\TheConsoomer\ClockInterface;
 
 /**
  * System clock implementation using current system time.
+ *
+ * now()   — returns wall-clock DateTimeImmutable (may go backward via NTP)
+ * monotonic() — returns hrtime(true), never decreases, safe for elapsed measurement
  */
 final class SystemClock implements ClockInterface
 {
@@ -17,5 +20,13 @@ final class SystemClock implements ClockInterface
     public function now(): \DateTimeImmutable
     {
         return new \DateTimeImmutable();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function monotonic(): float
+    {
+        return hrtime(true) / 1e9;
     }
 }

--- a/src/ClockInterface.php
+++ b/src/ClockInterface.php
@@ -12,7 +12,14 @@ namespace CrazyGoat\TheConsoomer;
 interface ClockInterface
 {
     /**
-     * Returns current DateTimeImmutable.
+     * Returns current DateTimeImmutable (wall-clock time).
      */
     public function now(): \DateTimeImmutable;
+
+    /**
+     * Returns a monotonic timestamp in seconds (never decreases).
+     *
+     * Use for measuring elapsed time intervals. Backed by hrtime(true) in production.
+     */
+    public function monotonic(): float;
 }

--- a/tests/Unit/CircuitBreakerTest.php
+++ b/tests/Unit/CircuitBreakerTest.php
@@ -6,6 +6,7 @@ namespace CrazyGoat\TheConsoomer\Tests\Unit;
 
 use CrazyGoat\TheConsoomer\CircuitBreaker;
 use CrazyGoat\TheConsoomer\CircuitState;
+use CrazyGoat\TheConsoomer\Tests\Unit\Clock\FrozenClock;
 use PHPUnit\Framework\TestCase;
 
 class CircuitBreakerTest extends TestCase
@@ -93,6 +94,48 @@ class CircuitBreakerTest extends TestCase
 
         $cb->recordSuccess();
         $this->assertSame(CircuitState::CLOSED, $cb->getState());
+    }
+
+    public function testMonotonicClockUsedForElapsedMeasurement(): void
+    {
+        $clock = new FrozenClock(new \DateTimeImmutable('2025-01-15 10:00:00'), 0.0);
+        $cb = new CircuitBreaker(
+            threshold: 1,
+            timeout: 60,
+            clock: $clock,
+        );
+
+        $cb->recordFailure();
+        $this->assertSame(CircuitState::OPEN, $cb->getState());
+        $this->assertFalse($cb->isAvailable());
+
+        $clock->advance(60);
+
+        $this->assertTrue($cb->isAvailable());
+        $this->assertSame(CircuitState::HALF_OPEN, $cb->getState());
+    }
+
+    public function testBackwardNtpStepDoesNotStickCircuitOpen(): void
+    {
+        $clock = new FrozenClock(new \DateTimeImmutable('2025-01-15 10:00:00'), 0.0);
+        $cb = new CircuitBreaker(
+            threshold: 1,
+            timeout: 60,
+            clock: $clock,
+        );
+
+        $cb->recordFailure();
+        $this->assertSame(CircuitState::OPEN, $cb->getState());
+        $this->assertFalse($cb->isAvailable());
+
+        $clock->advance(120);
+
+        $clock->advance(-120);
+
+        $this->assertSame('2025-01-15 10:00:00', $clock->now()->format('Y-m-d H:i:s'));
+
+        $this->assertTrue($cb->isAvailable());
+        $this->assertSame(CircuitState::HALF_OPEN, $cb->getState());
     }
 
     private function getSuccessThreshold(CircuitBreaker $cb): int

--- a/tests/Unit/Clock/FrozenClock.php
+++ b/tests/Unit/Clock/FrozenClock.php
@@ -8,13 +8,23 @@ use CrazyGoat\TheConsoomer\ClockInterface;
 
 final class FrozenClock implements ClockInterface
 {
-    public function __construct(private \DateTimeImmutable $time = new \DateTimeImmutable())
-    {
+    private float $monotonicTime;
+
+    public function __construct(
+        private \DateTimeImmutable $time = new \DateTimeImmutable(),
+        ?float $monotonicTime = null,
+    ) {
+        $this->monotonicTime = $monotonicTime ?? hrtime(true) / 1e9;
     }
 
     public function now(): \DateTimeImmutable
     {
         return $this->time;
+    }
+
+    public function monotonic(): float
+    {
+        return $this->monotonicTime;
     }
 
     public function advance(int $seconds): void
@@ -24,5 +34,9 @@ final class FrozenClock implements ClockInterface
             throw new \RuntimeException("Failed to advance time by {$seconds} seconds");
         }
         $this->time = $newTime;
+
+        if ($seconds > 0) {
+            $this->monotonicTime += $seconds;
+        }
     }
 }

--- a/tests/Unit/Clock/FrozenClockTest.php
+++ b/tests/Unit/Clock/FrozenClockTest.php
@@ -71,4 +71,42 @@ final class FrozenClockTest extends TestCase
 
         $this->assertSame('2025-01-15 10:03:30', $clock->now()->format('Y-m-d H:i:s'));
     }
+
+    public function testMonotonicReturnsFloat(): void
+    {
+        $clock = new FrozenClock();
+
+        $this->assertIsFloat($clock->monotonic());
+    }
+
+    public function testMonotonicIncreasesWithPositiveAdvance(): void
+    {
+        $clock = new FrozenClock(new \DateTimeImmutable('2025-01-15 10:00:00'), 0.0);
+
+        $this->assertSame(0.0, $clock->monotonic());
+
+        $clock->advance(60);
+
+        $this->assertSame(60.0, $clock->monotonic());
+    }
+
+    public function testMonotonicDoesNotIncreaseWithNegativeAdvance(): void
+    {
+        $clock = new FrozenClock(new \DateTimeImmutable('2025-01-15 10:00:00'), 100.0);
+
+        $clock->advance(-30);
+
+        $this->assertSame(100.0, $clock->monotonic());
+    }
+
+    public function testMonotonicNeverDecreases(): void
+    {
+        $clock = new FrozenClock(new \DateTimeImmutable('2025-01-15 10:00:00'), 0.0);
+
+        $clock->advance(60);
+        $this->assertSame(60.0, $clock->monotonic());
+
+        $clock->advance(-120);
+        $this->assertSame(60.0, $clock->monotonic());
+    }
 }


### PR DESCRIPTION
## Description

Fixes #237

NTP backward step can keep the circuit OPEN far longer than configured because `isAvailable()` computed elapsed time via `DateTimeImmutable` timestamps, which are not monotonic. A backward clock step makes elapsed negative, preventing the OPEN→HALF_OPEN transition.

## Changes

- **ClockInterface** — added `monotonic(): float` method
- **SystemClock** — implements `monotonic()` via `hrtime(true) / 1e9` (seconds since boot, never decreases)
- **CircuitBreaker** — replaced `lastFailureTime` (DateTimeImmutable) with `lastFailureMonotonic` (float). `isAvailable()` now computes elapsed from monotonic timestamps, immune to wall-clock corrections
- **FrozenClock** (test helper) — `monotonic()` value never decreases, even when `advance()` is called with a negative value (simulating NTP backward step)

## Testing

- Updated `FrozenClockTest` — 4 new tests covering monotonic behavior
- Added `CircuitBreakerTest::testMonotonicClockUsedForElapsedMeasurement` — verifies elapsed uses monotonic source
- Added `CircuitBreakerTest::testBackwardNtpStepDoesNotStickCircuitOpen` — verifies breaker recovers when wall clock jumps backward
- All 340 unit tests pass
- PHPStan level 3 passes