### PR TITLE
fix: reset setupPerformed on reconnect so topology is re-declared (#229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [Unreleased]
 
 ### Fixed
+- Topology is now re-declared after reconnect — `setupPerformed` flag is reset on reconnect so exchanges, queues, and bindings are re-declared on the new connection/channel (#229)
+  - Added `InfrastructureSetupInterface::resetSetup()` to allow clearing the setup-once flag
+  - `Receiver::ensureConnected()` calls `resetSetup()` after reconnecting
+  - `Receiver::get()`, `purgeQueue()`, and `getMessageCount()` reordered to run `setup()` after `ensureConnected()` — topology is declared on the fresh connection before consumers are created
 - Circuit-breaker elapsed-time now uses monotonic clock (`hrtime(true)`) instead of wall-clock `DateTimeImmutable` — prevents NTP backward step from sticking the circuit OPEN (#237)
   - Added `ClockInterface::monotonic(): float` method backed by `hrtime(true)` in `SystemClock`
   - `CircuitBreaker::recordFailure()` stores monotonic timestamp for elapsed measurement

--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -110,6 +110,11 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
         $this->setupPerformed = true;
     }
 
+    public function resetSetup(): void
+    {
+        $this->setupPerformed = false;
+    }
+
     /**
      * Creates and binds queues based on configuration.
      *

--- a/src/InfrastructureSetupInterface.php
+++ b/src/InfrastructureSetupInterface.php
@@ -19,4 +19,12 @@ interface InfrastructureSetupInterface
      * @throws \AMQPException When AMQP declaration fails
      */
     public function setup(): void;
+
+    /**
+     * Resets the setup state so the next call to setup() re-declares topology.
+     *
+     * Should be called after reconnecting to ensure exchanges, queues,
+     * and bindings are re-declared on the new connection/channel.
+     */
+    public function resetSetup(): void;
 }

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -72,6 +72,7 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
     {
         if ($this->connection->checkHeartbeat()) {
             $this->connection->reconnect();
+            $this->setup->resetSetup();
             $this->queues = [];
             $this->unacked = [];
             $this->lastUnacked = [];
@@ -98,10 +99,10 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
     public function get(): iterable
     {
         $this->messages = [];
+        $this->ensureConnected();
         if ($this->options['auto_setup'] ?? true) {
             $this->setup->setup();
         }
-        $this->ensureConnected();
         $this->connect();
 
         foreach ($this->queues as $queueName => $queue) {
@@ -244,10 +245,10 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
 
     public function purgeQueue(?string $queueName = null): int
     {
+        $this->ensureConnected();
         if ($this->options['auto_setup'] ?? true) {
             $this->setup->setup();
         }
-        $this->ensureConnected();
 
         $queueName ??= $this->options['queue'] ?? '';
         if ($queueName === '' && !isset($this->options['queues'])) {
@@ -278,10 +279,10 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
 
     public function getMessageCount(): int
     {
+        $this->ensureConnected();
         if ($this->options['auto_setup'] ?? true) {
             $this->setup->setup();
         }
-        $this->ensureConnected();
         $this->connect();
 
         $total = 0;

--- a/tests/Unit/InfrastructureSetupTest.php
+++ b/tests/Unit/InfrastructureSetupTest.php
@@ -70,6 +70,69 @@ class InfrastructureSetupTest extends TestCase
         $setup->setup();
     }
 
+    public function testSetupReExecutesAfterReset(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange, $this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue, $this->queue, $this->retryQueue);
+
+        $this->exchange->expects($this->exactly(2))->method('setName')->with('test_exchange');
+        $this->exchange->expects($this->exactly(2))->method('setType')->with(AMQP_EX_TYPE_DIRECT);
+        $this->exchange->expects($this->exactly(2))->method('declareExchange');
+        $this->exchange->method('getName')->willReturn('test_exchange');
+
+        $this->queue->expects($this->exactly(2))->method('setName')->with('test_queue');
+        $this->queue->expects($this->exactly(2))->method('declareQueue');
+        $this->queue->expects($this->exactly(2))->method('bind')->with('test_exchange', 'test_key');
+
+        $this->retryExchange->method('setName');
+        $this->retryExchange->method('setType');
+        $this->retryExchange->expects($this->exactly(2))->method('declareExchange');
+
+        $this->retryQueue->method('setName');
+        $this->retryQueue->method('setFlags');
+        $this->retryQueue->method('setArguments');
+        $this->retryQueue->expects($this->exactly(2))->method('declareQueue');
+        $this->retryQueue->expects($this->exactly(2))->method('bind');
+
+        $options = [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'routing_key' => 'test_key',
+        ];
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+
+        $setup->setup();
+        $setup->resetSetup();
+        $setup->setup();
+    }
+
+    public function testResetSetupCanBeCalledBeforeFirstSetup(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue);
+
+        $this->exchange->expects($this->once())->method('declareExchange');
+        $this->exchange->method('getName')->willReturn('test_exchange');
+        $this->queue->expects($this->once())->method('declareQueue');
+        $this->queue->expects($this->once())->method('bind');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'test_exchange',
+            'queue' => 'test_queue',
+            'routing_key' => 'test_key',
+        ]);
+
+        $setup->resetSetup();
+        $setup->setup();
+    }
+
     public function testSetupCreatesExchangeAndQueueWithCorrectParameters(): void
     {
         $this->connection


### PR DESCRIPTION
## Summary

`InfrastructureSetup::$setupPerformed` prevents topology re-declaration after broker restart + consumer reconnect. Long-running consumers with auto-reconnect find missing exchanges/queues and fail silently.

## Changes

- **`InfrastructureSetupInterface`**: Added `resetSetup(): void` — allows clearing the setup-once flag
- **`InfrastructureSetup`**: Implemented `resetSetup()` — sets `$setupPerformed = false` so the next `setup()` call re-declares topology
- **`Receiver::ensureConnected()`**: Calls `$this->setup->resetSetup()` after `$this->connection->reconnect()` — ensures topology is re-declared on the new connection
- **`Receiver::get()`**: Reordered to run `setup()` after `ensureConnected()` — topology is declared on the fresh connection before consumers are created

## Testing

- Existing `testSetupIsIdempotentAndOnlyExecutesOnce` continues to pass (idempotency without reset is preserved)
- Added `testSetupReExecutesAfterReset` — verifies `setup()` re-declares everything after `resetSetup()`
- Added `testResetSetupCanBeCalledBeforeFirstSetup` — verifies no side effects when resetting before first setup

Closes #229