### PR TITLE
fix: rename retryCount to maxAttempts with validation (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## [Unreleased]
 
+### Changed
+- **BC BREAK**: Renamed `ConnectionRetry::$retryCount` constructor parameter to `maxAttempts` to clarify semantics (#228)
+  - `retryCount` previously meant "total attempts" (ambiguous) — now `maxAttempts` explicitly means "maximum number of execution attempts including the first"
+  - Config key `retry_count` in DSN/options remains unchanged and maps to `maxAttempts`
+  - Validation added: `maxAttempts` must be at least 1 (throws `\InvalidArgumentException` for 0 or negative)
+  - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
+
 ### Fixed
 - Topology is now re-declared after reconnect — `setupPerformed` flag is reset on reconnect so exchanges, queues, and bindings are re-declared on the new connection/channel (#229)
   - Added `InfrastructureSetupInterface::resetSetup()` to allow clearing the setup-once flag

--- a/README.md
+++ b/README.md
@@ -105,6 +105,37 @@ With heartbeat enabled:
 - If stale (elapsed > 2 * heartbeat), automatic reconnect occurs
 - Activity is updated after each operation
 
+### Retry Configuration
+
+The transport supports configurable retry logic with exponential backoff, jitter, and circuit breaker.
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `retry` | Enable retry mechanism | `false` |
+| `retry_count` | Maximum number of execution attempts including the first (`maxAttempts`) | `3` |
+| `retry_delay` | Base delay between retries in microseconds | `100000` |
+| `retry_backoff` | Enable exponential backoff (delay doubles each retry) | `false` |
+| `retry_max_delay` | Maximum delay cap in microseconds | `30000000` |
+| `retry_jitter` | Enable random jitter (±25%) to prevent thundering herd | `true` |
+| `retry_circuit_breaker` | Enable circuit breaker pattern | `false` |
+| `retry_circuit_breaker_threshold` | Consecutive failures before circuit opens | `10` |
+| `retry_circuit_breaker_timeout` | Seconds circuit stays open before half-open probe | `60` |
+| `retry_circuit_breaker_success_threshold` | Successful attempts needed to close circuit | `2` |
+
+```yaml
+framework:
+    messenger:
+        transports:
+            consoomer:
+                dsn: 'amqp-consoomer://guest:guest@localhost:5672/%2f/?queue=my_queue&retry=1&retry_count=3&retry_delay=500000&retry_backoff=1&retry_jitter=1&retry_circuit_breaker=1'
+```
+
+With retry enabled:
+- Connection and channel failures are retried automatically up to `retry_count` times (including the first attempt)
+- Non-AMQP exceptions are not retried
+- Permanent AMQP errors (403, 404, 406) are not retried
+- On exhaustion, a `RetryExhaustedException` is thrown with the last failure as previous
+
 ## Testing
 
 ### Run tests

--- a/src/AmqpTransportFactory.php
+++ b/src/AmqpTransportFactory.php
@@ -18,7 +18,7 @@ use Symfony\Component\Messenger\Transport\TransportInterface;
 class AmqpTransportFactory implements TransportFactoryInterface
 {
     private const DEFAULT_READ_TIMEOUT = 0.1;
-    private const DEFAULT_RETRY_COUNT = 3;
+    private const DEFAULT_MAX_ATTEMPTS = 3;
     private const DEFAULT_RETRY_DELAY = 100_000;
     private const DEFAULT_RETRY_MAX_DELAY = 30_000_000;
 
@@ -175,7 +175,7 @@ class AmqpTransportFactory implements TransportFactoryInterface
     {
         if ($options['retry'] ?? false) {
             return new ConnectionRetry(
-                retryCount: (int) ($options['retry_count'] ?? self::DEFAULT_RETRY_COUNT),
+                maxAttempts: (int) ($options['retry_count'] ?? self::DEFAULT_MAX_ATTEMPTS),
                 retryDelay: (int) ($options['retry_delay'] ?? self::DEFAULT_RETRY_DELAY),
                 retryBackoff: (bool) ($options['retry_backoff'] ?? false),
                 retryMaxDelay: (int) ($options['retry_max_delay'] ?? self::DEFAULT_RETRY_MAX_DELAY),

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -31,7 +31,7 @@ final class ConnectionRetry implements ConnectionRetryInterface
     private readonly RetryMetrics $metrics;
 
     /**
-     * @param int                    $retryCount                        Number of retry attempts
+     * @param int                    $maxAttempts                       Maximum number of execution attempts (including the first, minimum: 1)
      * @param int                    $retryDelay                        Base delay between retries in microseconds
      * @param bool                   $retryBackoff                      Enable exponential backoff
      * @param int                    $retryMaxDelay                     Maximum delay cap in microseconds
@@ -44,7 +44,7 @@ final class ConnectionRetry implements ConnectionRetryInterface
      * @param ClockInterface|null    $clock                             Clock for time tracking
      */
     public function __construct(
-        private readonly int $retryCount = 3,
+        private readonly int $maxAttempts = 3,
         private readonly int $retryDelay = 100000,
         private readonly bool $retryBackoff = false,
         private readonly int $retryMaxDelay = 30000000,
@@ -56,6 +56,13 @@ final class ConnectionRetry implements ConnectionRetryInterface
         private readonly ?LoggerInterface $logger = null,
         private readonly ?ClockInterface $clock = new SystemClock(),
     ) {
+        if ($this->maxAttempts < 1) {
+            throw new \InvalidArgumentException(sprintf(
+                'maxAttempts must be at least 1, %d given',
+                $this->maxAttempts,
+            ));
+        }
+
         $this->metrics = new RetryMetrics();
 
         if ($this->retryCircuitBreaker) {
@@ -91,7 +98,7 @@ final class ConnectionRetry implements ConnectionRetryInterface
         $attempt = 0;
         $lastException = null;
 
-        while ($attempt < $this->retryCount) {
+        while ($attempt < $this->maxAttempts) {
             try {
                 $result = $operation();
 
@@ -119,14 +126,14 @@ final class ConnectionRetry implements ConnectionRetryInterface
                 $lastException = $exception;
                 $attempt++;
 
-                if ($attempt >= $this->retryCount) {
+                if ($attempt >= $this->maxAttempts) {
                     break;
                 }
 
                 $delay = $this->calculateDelay($attempt);
                 $this->logger?->error('Retry attempt failed', [
                     'attempt' => $attempt,
-                    'max_attempts' => $this->retryCount,
+                    'max_attempts' => $this->maxAttempts,
                     'delay' => $delay,
                     'error' => $exception->getMessage(),
                 ]);
@@ -147,7 +154,7 @@ final class ConnectionRetry implements ConnectionRetryInterface
         }
 
         $this->logger?->error('Retry failed after max attempts', [
-            'max_attempts' => $this->retryCount,
+            'max_attempts' => $this->maxAttempts,
             'error' => $lastException?->getMessage(),
         ]);
 

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -20,29 +20,25 @@ class ConnectionRetryTest extends TestCase
 
     public function testSuccessfulOperationNoRetry(): void
     {
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $result = $retry->withRetry(fn(): string => 'success');
 
         $this->assertSame('success', $result);
     }
 
-    public function testRetryCountZeroThrowsRuntimeException(): void
+    public function testMaxAttemptsZeroThrowsInvalidArgumentException(): void
     {
-        $retry = new ConnectionRetry(retryCount: 0, retryDelay: 1000);
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('maxAttempts must be at least 1');
 
-        $this->expectException(RetryExhaustedException::class);
-        $this->expectExceptionMessage('Operation failed with no retries configured');
-
-        $retry->withRetry(function (): void {
-            throw new \AMQPConnectionException('Connection failed');
-        });
+        new ConnectionRetry(maxAttempts: 0, retryDelay: 1000);
     }
 
     public function testRetryOnConnectionException(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $this->expectException(RetryExhaustedException::class);
 
@@ -57,7 +53,7 @@ class ConnectionRetryTest extends TestCase
     public function testRetrySucceedsOnSecondAttempt(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $result = $retry->withRetry(function () use (&$attempt): string {
             $attempt++;
@@ -73,7 +69,7 @@ class ConnectionRetryTest extends TestCase
 
     public function testNoRetryOnOtherException(): void
     {
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $this->expectException(UnexpectedOperationException::class);
 
@@ -85,7 +81,7 @@ class ConnectionRetryTest extends TestCase
     public function testRetryOnChannelException(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $this->expectException(RetryExhaustedException::class);
 
@@ -100,7 +96,7 @@ class ConnectionRetryTest extends TestCase
     public function testRetryOnExchangeException(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $this->expectException(RetryExhaustedException::class);
 
@@ -115,7 +111,7 @@ class ConnectionRetryTest extends TestCase
     public function testRetryOnQueueException(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $this->expectException(RetryExhaustedException::class);
 
@@ -130,7 +126,7 @@ class ConnectionRetryTest extends TestCase
     public function testRetrySucceedsOnSecondAttemptWithChannelException(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         $result = $retry->withRetry(function () use (&$attempt): string {
             $attempt++;
@@ -147,7 +143,7 @@ class ConnectionRetryTest extends TestCase
     public function testNoRetryOnQueueNotFound(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         try {
             $retry->withRetry(function () use (&$attempt): void {
@@ -164,7 +160,7 @@ class ConnectionRetryTest extends TestCase
     public function testNoRetryOnExchangeNotFound(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         try {
             $retry->withRetry(function () use (&$attempt): void {
@@ -181,7 +177,7 @@ class ConnectionRetryTest extends TestCase
     public function testNoRetryOnAccessDenied(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         try {
             $retry->withRetry(function () use (&$attempt): void {
@@ -198,7 +194,7 @@ class ConnectionRetryTest extends TestCase
     public function testNoRetryOnPreconditionFailed(): void
     {
         $attempt = 0;
-        $retry = new ConnectionRetry(retryCount: 3, retryDelay: 1000);
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
         try {
             $retry->withRetry(function () use (&$attempt): void {
@@ -215,7 +211,7 @@ class ConnectionRetryTest extends TestCase
     public function testCircuitBreakerOpensAfterThreshold(): void
     {
         $retry = new ConnectionRetry(
-            retryCount: 3,
+            maxAttempts: 3,
             retryDelay: 1000,
             retryCircuitBreaker: true,
             retryCircuitBreakerThreshold: 2,
@@ -240,7 +236,7 @@ class ConnectionRetryTest extends TestCase
         $clock = new FrozenClock();
 
         $retry = new ConnectionRetry(
-            retryCount: 1,
+            maxAttempts: 1,
             retryDelay: 1000,
             retryCircuitBreaker: true,
             retryCircuitBreakerThreshold: 1,
@@ -267,7 +263,7 @@ class ConnectionRetryTest extends TestCase
     public function testExponentialBackoff(): void
     {
         $retry = new ConnectionRetry(
-            retryCount: 3,
+            maxAttempts: 3,
             retryDelay: 100000,
             retryBackoff: true,
             retryJitter: false,
@@ -292,7 +288,7 @@ class ConnectionRetryTest extends TestCase
     {
         for ($i = 0; $i < 10; $i++) {
             $retry = new ConnectionRetry(
-                retryCount: 2,
+                maxAttempts: 2,
                 retryDelay: 100000,
                 retryBackoff: false,
                 retryJitter: true,
@@ -314,7 +310,7 @@ class ConnectionRetryTest extends TestCase
     public function testResetsCircuitBreaker(): void
     {
         $retry = new ConnectionRetry(
-            retryCount: 1,
+            maxAttempts: 1,
             retryDelay: 1000,
             retryCircuitBreaker: true,
             retryCircuitBreakerThreshold: 1,
@@ -344,7 +340,7 @@ class ConnectionRetryTest extends TestCase
         $clock = new FrozenClock();
 
         $retry = new ConnectionRetry(
-            retryCount: 1,
+            maxAttempts: 1,
             retryDelay: 1000,
             retryCircuitBreaker: true,
             retryCircuitBreakerThreshold: 1,
@@ -363,7 +359,7 @@ class ConnectionRetryTest extends TestCase
         $clock = new FrozenClock();
 
         $retry = new ConnectionRetry(
-            retryCount: 1,
+            maxAttempts: 1,
             retryDelay: 1000,
             retryCircuitBreaker: true,
             retryCircuitBreakerThreshold: 1,
@@ -397,7 +393,7 @@ class ConnectionRetryTest extends TestCase
         $clock = new FrozenClock();
 
         $retry = new ConnectionRetry(
-            retryCount: 1,
+            maxAttempts: 1,
             retryDelay: 1000,
             retryCircuitBreaker: true,
             retryCircuitBreakerThreshold: 1,
@@ -434,7 +430,7 @@ class ConnectionRetryTest extends TestCase
         $this->expectExceptionMessage('successThreshold must be at least 2');
 
         new ConnectionRetry(
-            retryCount: 1,
+            maxAttempts: 1,
             retryDelay: 1000,
             retryCircuitBreaker: true,
             retryCircuitBreakerThreshold: 1,

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -67,6 +67,36 @@ class ConnectionRetryTest extends TestCase
         $this->assertSame(2, $attempt);
     }
 
+    public function testMaxAttemptsOneExecutesExactlyOneAttempt(): void
+    {
+        $attempt = 0;
+        $retry = new ConnectionRetry(maxAttempts: 1, retryDelay: 1000);
+
+        $this->expectException(RetryExhaustedException::class);
+
+        $retry->withRetry(function () use (&$attempt): void {
+            $attempt++;
+            throw new \AMQPConnectionException('Connection failed');
+        });
+
+        $this->assertSame(1, $attempt);
+    }
+
+    public function testMaxAttemptsTwoExecutesExactlyTwoAttempts(): void
+    {
+        $attempt = 0;
+        $retry = new ConnectionRetry(maxAttempts: 2, retryDelay: 1000);
+
+        $this->expectException(RetryExhaustedException::class);
+
+        $retry->withRetry(function () use (&$attempt): void {
+            $attempt++;
+            throw new \AMQPConnectionException('Connection failed');
+        });
+
+        $this->assertSame(2, $attempt);
+    }
+
     public function testNoRetryOnOtherException(): void
     {
         $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);


### PR DESCRIPTION
## Summary

Fixes #228 — `retry_count` has off-by-one semantics and a silent no-op edge. Renamed the internal parameter from the ambiguous `retryCount` to `maxAttempts` to make semantics unambiguous.

## Changes

### Code
- **`ConnectionRetry::$retryCount`** → **`maxAttempts`** (constructor parameter)
- Added validation: throws `\InvalidArgumentException` when `maxAttempts < 1`
- `AmqpTransportFactory::DEFAULT_RETRY_COUNT` → `DEFAULT_MAX_ATTEMPTS`
- Updated named argument in `createRetry()`

The DSN config key `retry_count` remains unchanged for backward compatibility.

### Tests
- Updated all `retryCount:` named arguments to `maxAttempts:`
- Replaced `testRetryCountZeroThrowsRuntimeException` with `testMaxAttemptsZeroThrowsInvalidArgumentException`

### Documentation
- Added retry configuration table and example to `README.md`
- Added CHANGELOG entry under `### Changed`

## BC Break
Direct instantiation with named argument `retryCount:` must use `maxAttempts:` instead. Config key `retry_count` in DSN/options is unaffected.