### PR TITLE
fix: use rawurldecode() for DSN userinfo and path segments (#245)

### DIFF
--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -67,8 +67,8 @@ final class DsnParser
         $result = [
             'host' => $info['host'] ?? 'localhost',
             'port' => $info['port'] ?? 5672,
-            'user' => urldecode($info['user'] ?? 'guest'),
-            'password' => urldecode($info['pass'] ?? 'guest'),
+            'user' => rawurldecode($info['user'] ?? 'guest'),
+            'password' => rawurldecode($info['pass'] ?? 'guest'),
             'vhost' => $pathOptions['vhost'],
             'exchange' => $pathOptions['exchange'],
         ];
@@ -189,8 +189,8 @@ final class DsnParser
         $items = explode('/', trim($path, " \n\r\t\v\0/"));
 
         return [
-            'vhost' => urldecode($items[0] ?? '/'),
-            'exchange' => urldecode($items[1] ?? ''),
+            'vhost' => rawurldecode($items[0] ?? '/'),
+            'exchange' => rawurldecode($items[1] ?? ''),
         ];
     }
 

--- a/tests/Unit/DsnParserTest.php
+++ b/tests/Unit/DsnParserTest.php
@@ -239,14 +239,14 @@ class DsnParserTest extends TestCase
         $this->assertSame('pass%word', $result['password']);
     }
 
-    public function testParsesUrlEncodedSpaces(): void
+    public function testParsesUrlEncodedSpaceAndLiteralPlus(): void
     {
         $parser = new DsnParser();
-        // Test spaces encoded as %20 and +
-        // Note: urldecode() treats + as space, which is correct for URL-encoded form data
+        // %20 decodes to space; + is literal in URI userinfo (not a space)
+        // rawurldecode correctly preserves +, unlike urldecode which converts it to space
         $result = $parser->parse('amqp-consoomer://user%20name:pass+word@localhost/%2f/my_exchange');
 
         $this->assertSame('user name', $result['user']);
-        $this->assertSame('pass word', $result['password']);
+        $this->assertSame('pass+word', $result['password']);
     }
 }


### PR DESCRIPTION
## Description

`urldecode()` converts `+` to space (application/x-www-form-urlencoded behavior), but in a URI the userinfo and path components should be decoded with `rawurldecode()` — `+` is a literal character, not an encoded space.

This means a password like `my+password` in a DSN is silently corrupted to `my password`, breaking authentication.

## Changes

- `src/DsnParser.php`: Replace `urldecode()` with `rawurldecode()` for `user`, `password`, `vhost`, and `exchange` fields
- `tests/Unit/DsnParserTest.php`: Update `testParsesUrlEncodedSpaces` → `testParsesUrlEncodedSpaceAndLiteralPlus` to expect `+` preserved in password

## Testing

- All 344 unit tests pass
- Existing `%2B` → `+` tests continue to pass (both functions decode percent-encoded sequences identically)
- PHPStan passes with no errors
- CS fixer clean

Fixes #245