### PR TITLE
fix: relax AmqpPriorityStamp priority cap from 9 to 255 (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- `AmqpPriorityStamp` priority cap relaxed from 9 to 255 — RabbitMQ supports up to 255 via `x-max-priority` queue argument (#227)
 - Topology is now re-declared after reconnect — `setupPerformed` flag is reset on reconnect so exchanges, queues, and bindings are re-declared on the new connection/channel (#229)
   - Added `InfrastructureSetupInterface::resetSetup()` to allow clearing the setup-once flag
   - `Receiver::ensureConnected()` calls `resetSetup()` after reconnecting

--- a/src/AmqpPriorityStamp.php
+++ b/src/AmqpPriorityStamp.php
@@ -7,18 +7,20 @@ namespace CrazyGoat\TheConsoomer;
 use Symfony\Component\Messenger\Stamp\NonSendableStampInterface;
 
 /**
- * Stamp that holds explicit message priority (0-9) for AMQP publish.
+ * Stamp that holds explicit message priority (0-255) for AMQP publish.
  *
  * Higher priority messages are processed before lower priority ones.
  * Requires the queue to be configured with x-max-priority argument.
+ *
+ * RabbitMQ supports priority values 0-255 via the x-max-priority queue argument.
  */
 final readonly class AmqpPriorityStamp implements NonSendableStampInterface
 {
     public function __construct(
         private int $priority,
     ) {
-        if ($priority < 0 || $priority > 9) {
-            throw new \InvalidArgumentException(sprintf('Priority must be between 0 and 9, got %d', $priority));
+        if ($priority < 0 || $priority > 255) {
+            throw new \InvalidArgumentException(sprintf('Priority must be between 0 and 255, got %d', $priority));
         }
     }
 

--- a/tests/Unit/AmqpPriorityStampTest.php
+++ b/tests/Unit/AmqpPriorityStampTest.php
@@ -32,16 +32,23 @@ class AmqpPriorityStampTest extends TestCase
 
     public function testAllowsMaxPriority(): void
     {
-        $stamp = new AmqpPriorityStamp(9);
+        $stamp = new AmqpPriorityStamp(255);
 
-        $this->assertSame(9, $stamp->getPriority());
+        $this->assertSame(255, $stamp->getPriority());
+    }
+
+    public function testAllowsHighPriority(): void
+    {
+        $stamp = new AmqpPriorityStamp(10);
+
+        $this->assertSame(10, $stamp->getPriority());
     }
 
     /** @dataProvider invalidPriorityProvider */
     public function testInvalidPriorityThrowsException(int $priority): void
     {
         $this->expectException(\InvalidArgumentException::class);
-        $this->expectExceptionMessage('Priority must be between 0 and 9');
+        $this->expectExceptionMessage('Priority must be between 0 and 255');
 
         new AmqpPriorityStamp($priority);
     }
@@ -51,7 +58,7 @@ class AmqpPriorityStampTest extends TestCase
     {
         return [
             'negative' => [-1],
-            'too high' => [10],
+            'too high' => [256],
         ];
     }
 }


### PR DESCRIPTION
## Summary

`AmqpPriorityStamp` hard-capped priority at 9, but RabbitMQ priority queues support `x-max-priority` up to 255. This blocked legitimate higher-priority setups despite the broker supporting them.

## Changes

- Relaxed priority validation from `0 <= priority <= 9` to `0 <= priority <= 255`
- Updated class docblock to reflect the actual AMQP capability (not a library limit)
- Updated tests: `testAllowsMaxPriority` now tests 255, added `testAllowsHighPriority` for 10, changed invalid provider to 256

Closes #227