### PR TITLE
fix: preserve priority/delivery_mode/timestamp 0 in AmqpStamp::createFromAmqpEnvelope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- `AmqpStamp::createFromAmqpEnvelope()` no longer drops `priority`, `delivery_mode`, or `timestamp` when their value is `0` — priority 0 is a valid AMQP level that was lost on receive→re-send round-trips (#226)
 - `AmqpPriorityStamp` priority cap relaxed from 9 to 255 — RabbitMQ supports up to 255 via `x-max-priority` queue argument (#227)
 - Topology is now re-declared after reconnect — `setupPerformed` flag is reset on reconnect so exchanges, queues, and bindings are re-declared on the new connection/channel (#229)
   - Added `InfrastructureSetupInterface::resetSetup()` to allow clearing the setup-once flag

--- a/src/AmqpStamp.php
+++ b/src/AmqpStamp.php
@@ -96,6 +96,9 @@ final readonly class AmqpStamp implements NonSendableStampInterface
             'content_type' => $envelope->getContentType(),
             'content_encoding' => $envelope->getContentEncoding(),
             'message_id' => $envelope->getMessageId(),
+            'delivery_mode' => $envelope->getDeliveryMode(),
+            'priority' => $envelope->getPriority(),
+            'timestamp' => $envelope->getTimestamp(),
             'app_id' => $envelope->getAppId(),
             'user_id' => $envelope->getUserId(),
             'expiration' => $envelope->getExpiration(),
@@ -111,18 +114,6 @@ final readonly class AmqpStamp implements NonSendableStampInterface
             }
 
             $attributes[$key] = $value;
-        }
-
-        if ($envelope->getDeliveryMode() > 0) {
-            $attributes['delivery_mode'] = $envelope->getDeliveryMode();
-        }
-
-        if ($envelope->getPriority() > 0) {
-            $attributes['priority'] = $envelope->getPriority();
-        }
-
-        if ($envelope->getTimestamp() > 0) {
-            $attributes['timestamp'] = $envelope->getTimestamp();
         }
 
         return new self($envelope->getRoutingKey(), \AMQP_NOPARAM, $attributes, false);

--- a/tests/Unit/AmqpStampTest.php
+++ b/tests/Unit/AmqpStampTest.php
@@ -118,12 +118,12 @@ class AmqpStampTest extends TestCase
         $this->assertSame([
             'content_type' => 'application/json',
             'message_id' => 'msg-123',
-            'app_id' => 'test-app',
-            'correlation_id' => 'corr-456',
-            'headers' => ['x-custom' => 'value'],
             'delivery_mode' => 2,
             'priority' => 5,
             'timestamp' => 1234567890,
+            'app_id' => 'test-app',
+            'correlation_id' => 'corr-456',
+            'headers' => ['x-custom' => 'value'],
         ], $stamp->getAttributes());
     }
 
@@ -148,10 +148,14 @@ class AmqpStampTest extends TestCase
         $stamp = AmqpStamp::createFromAmqpEnvelope($envelope);
 
         $this->assertSame('', $stamp->getRoutingKey());
-        $this->assertSame([], $stamp->getAttributes());
+        $this->assertSame([
+            'delivery_mode' => 0,
+            'priority' => 0,
+            'timestamp' => 0,
+        ], $stamp->getAttributes());
     }
 
-    public function testCreateFromAmqpEnvelopeFiltersPriorityZero(): void
+    public function testCreateFromAmqpEnvelopePreservesPriorityZero(): void
     {
         $envelope = $this->createMock(\AMQPEnvelope::class);
         $envelope->method('getRoutingKey')->willReturn('');
@@ -171,7 +175,7 @@ class AmqpStampTest extends TestCase
 
         $stamp = AmqpStamp::createFromAmqpEnvelope($envelope);
 
-        $this->assertSame(['delivery_mode' => 2], $stamp->getAttributes());
+        $this->assertSame(['delivery_mode' => 2, 'priority' => 0], $stamp->getAttributes());
     }
 
     public function testCreateWithAttributes(): void
@@ -214,6 +218,10 @@ class AmqpStampTest extends TestCase
         $stamp = AmqpStamp::createFromAmqpEnvelope($envelope);
 
         $this->assertSame('test.routing.key', $stamp->getRoutingKey());
-        $this->assertSame([], $stamp->getAttributes());
+        $this->assertSame([
+            'delivery_mode' => 0,
+            'priority' => 0,
+            'timestamp' => 0,
+        ], $stamp->getAttributes());
     }
 }

--- a/tests/Unit/AmqpStampTest.php
+++ b/tests/Unit/AmqpStampTest.php
@@ -197,7 +197,7 @@ class AmqpStampTest extends TestCase
         $this->assertSame(['new' => 'attribute'], $stamp->getAttributes());
     }
 
-    public function testCreateFromEmptyAmqpEnvelopeReturnsEmptyAttributes(): void
+    public function testCreateFromAmqpEnvelopePreservesZeroIntValues(): void
     {
         $envelope = $this->createMock(\AMQPEnvelope::class);
         $envelope->method('getRoutingKey')->willReturn('test.routing.key');


### PR DESCRIPTION
Closes #226

## Summary

`AmqpStamp::createFromAmqpEnvelope()` used `> 0` guards for `delivery_mode`, `priority`, and `timestamp`, which silently dropped a value of `0`. Priority `0` is a valid AMQP level (lowest priority), *not* an "unset" sentinel. A receive → re-send round-trip lost explicit `priority 0`.

## Changes

### Source (`src/AmqpStamp.php`)
- Moved `delivery_mode`, `priority`, `timestamp` into the `attributeMap` array so they flow through the existing null/empty/false filter
- Removed the three separate `if (... > 0)` blocks
- Since `\AMQPEnvelope` getters return `int` (non-nullable), the filter correctly passes `0` through while still filtering truly empty/null values from other attributes

### Tests (`tests/Unit/AmqpStampTest.php`)
- `testCreateFromAmqpEnvelopeFiltersPriorityZero` → renamed to `testCreateFromAmqpEnvelopePreservesPriorityZero`, now asserts `priority => 0` is included
- `testCreateFromAmqpEnvelopeFiltersEmptyValues` now asserts zero-valued int attributes are preserved
- `testCreateFromEmptyAmqpEnvelopeReturnsEmptyAttributes` now asserts zero-valued int attributes are included
- Updated attribute order in `testCreateFromAmqpEnvelope` to match new insertion order

### Changelog
- Entry in `CHANGELOG.md` under `### Fixed`

## Impact

| Scenario | Before | After |
|---|---|---|
| Envelope with `priority=0` | `priority` dropped from attributes | `priority => 0` preserved |
| `delivery_mode=0, timestamp=0` | silently dropped | preserved |