### PR TITLE
fix: apply jitter before max-delay cap to prevent exceeding retry_max_delay (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- Retry jitter is now applied BEFORE the `retry_max_delay` cap — jitter no longer pushes the effective delay up to 25% above the configured maximum (#225)
 - `AmqpStamp::createFromAmqpEnvelope()` no longer drops `priority`, `delivery_mode`, or `timestamp` when their value is `0` — priority 0 is a valid AMQP level that was lost on receive→re-send round-trips (#226)
 - `AmqpPriorityStamp` priority cap relaxed from 9 to 255 — RabbitMQ supports up to 255 via `x-max-priority` queue argument (#227)
 - Topology is now re-declared after reconnect — `setupPerformed` flag is reset on reconnect so exchanges, queues, and bindings are re-declared on the new connection/channel (#229)

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -218,13 +218,11 @@ final class ConnectionRetry implements ConnectionRetryInterface
             $delay = $this->retryDelay * (2 ** ($attempt - 1));
         }
 
-        $delay = min($delay, $this->retryMaxDelay);
-
         if ($this->retryJitter) {
             $variation = (int) ($delay * self::JITTER_VARIATION_FACTOR);
             $delay += random_int(-$variation, $variation);
         }
 
-        return max(0, $delay);
+        return max(0, min($delay, $this->retryMaxDelay));
     }
 }

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -290,6 +290,45 @@ class ConnectionRetryTest extends TestCase
         $this->assertSame('success', $result);
     }
 
+    public function testJitterNeverExceedsMaxDelay(): void
+    {
+        $retry = new ConnectionRetry(
+            maxAttempts: 1,
+            retryDelay: 100000,
+            retryBackoff: false,
+            retryMaxDelay: 100000,
+            retryJitter: true,
+        );
+
+        $calculateDelay = (new \ReflectionMethod($retry, 'calculateDelay'))->getClosure($retry);
+
+        for ($i = 0; $i < 1000; $i++) {
+            $delay = $calculateDelay(1);
+            $this->assertLessThanOrEqual(100000, $delay, 'Jittered delay must not exceed retryMaxDelay');
+            $this->assertGreaterThanOrEqual(0, $delay, 'Delay must be non-negative');
+        }
+    }
+
+    public function testJitterWithBackoffNeverExceedsMaxDelay(): void
+    {
+        $retry = new ConnectionRetry(
+            maxAttempts: 1,
+            retryDelay: 1000,
+            retryBackoff: true,
+            retryMaxDelay: 100000,
+            retryJitter: true,
+        );
+
+        $calculateDelay = (new \ReflectionMethod($retry, 'calculateDelay'))->getClosure($retry);
+
+        for ($attempt = 1; $attempt <= 10; $attempt++) {
+            for ($i = 0; $i < 100; $i++) {
+                $delay = $calculateDelay($attempt);
+                $this->assertLessThanOrEqual(100000, $delay, 'Backoff jittered delay must not exceed retryMaxDelay');
+            }
+        }
+    }
+
     public function testExponentialBackoff(): void
     {
         $retry = new ConnectionRetry(


### PR DESCRIPTION
## Summary

Fixes jitter ordering bug: random jitter was applied **after** the `retry_max_delay` cap, so the effective delay could exceed the configured maximum by up to 25% (jitter factor).

## Changes

- **src/ConnectionRetry.php**: Apply jitter BEFORE clamping to `retryMaxDelay`, then cap and ensure non-negative
- **tests/Unit/ConnectionRetryTest.php**: Added `testJitterNeverExceedsMaxDelay()` and `testJitterWithBackoffNeverExceedsMaxDelay()` — 1000 iterations each via reflection to verify the cap is never violated
- **CHANGELOG.md**: Added entry under `### Fixed`

## Acceptance Criteria

- [x] Jitter applied before max-delay cap
- [x] Unit tests verify delay never exceeds `retryMaxDelay`
- [x] Existing 347 tests pass
- [x] phpstan, php-cs-fixer, rector all clean

Closes #225