### PR TITLE
fix: circuit-breaker HALF_OPEN single-probe defeated by retry loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- Circuit-breaker HALF_OPEN single-probe semantics are no longer defeated by the retry loop — when the circuit transitions to HALF_OPEN the operation is executed exactly once (not `retryCount` times), preserving the failure-isolation the feature advertises (#223)
 - Retry jitter is now applied BEFORE the `retry_max_delay` cap — jitter no longer pushes the effective delay up to 25% above the configured maximum (#225)
 - `AmqpStamp::createFromAmqpEnvelope()` no longer drops `priority`, `delivery_mode`, or `timestamp` when their value is `0` — priority 0 is a valid AMQP level that was lost on receive→re-send round-trips (#226)
 - `AmqpPriorityStamp` priority cap relaxed from 9 to 255 — RabbitMQ supports up to 255 via `x-max-priority` queue argument (#227)

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -89,10 +89,16 @@ final class ConnectionRetry implements ConnectionRetryInterface
      */
     public function withRetry(callable $operation): mixed
     {
-        if ($this->retryCircuitBreaker && $this->circuitBreaker instanceof \CrazyGoat\TheConsoomer\CircuitBreaker && !$this->circuitBreaker->isAvailable()) {
-            $this->logger?->error('Circuit breaker is open, rejecting operation');
-            $this->metrics->recordCircuitBreakerOpen();
-            throw new CircuitBreakerOpenException('Circuit breaker is open');
+        if ($this->retryCircuitBreaker && $this->circuitBreaker instanceof \CrazyGoat\TheConsoomer\CircuitBreaker) {
+            if (!$this->circuitBreaker->isAvailable()) {
+                $this->logger?->error('Circuit breaker is open, rejecting operation');
+                $this->metrics->recordCircuitBreakerOpen();
+                throw new CircuitBreakerOpenException('Circuit breaker is open');
+            }
+
+            if ($this->circuitBreaker->getState() === CircuitState::HALF_OPEN) {
+                return $this->executeHalfOpenProbe($operation);
+            }
         }
 
         $attempt = 0;
@@ -202,6 +208,46 @@ final class ConnectionRetry implements ConnectionRetryInterface
     {
         $this->circuitBreaker?->reset();
         $this->metrics->reset();
+    }
+
+    /**
+     * Executes operation exactly once as a half-open probe.
+     *
+     * In half-open state, no retry loop is used — exactly one attempt is made
+     * and the result is recorded directly to the circuit breaker.
+     *
+     * @template T
+     * @param callable(): T $operation Operation to execute
+     * @return T
+     * @throws \AMQPException When AMQP operation fails (breaker is re-opened)
+     * @throws UnexpectedOperationException When non-AMQP exception occurs
+     */
+    private function executeHalfOpenProbe(callable $operation): mixed
+    {
+        try {
+            $result = $operation();
+
+            $this->circuitBreaker?->recordSuccess();
+            $this->metrics->recordAttempt();
+
+            return $result;
+        } catch (\AMQPException $exception) {
+            $this->circuitBreaker?->recordFailure();
+            $this->metrics->recordFailure();
+
+            $this->logger?->warning('Half-open probe failed, circuit re-opening', [
+                'code' => $exception->getCode(),
+                'error' => $exception->getMessage(),
+            ]);
+
+            throw $exception;
+        } catch (\Throwable $exception) {
+            $this->logger?->warning('Non-AMQP exception during half-open probe', [
+                'error' => $exception->getMessage(),
+            ]);
+
+            throw UnexpectedOperationException::fromPrevious($exception);
+        }
     }
 
     /**

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -493,6 +493,180 @@ class ConnectionRetryTest extends TestCase
         $this->assertSame(CircuitState::CLOSED, $retry->getState());
     }
 
+    public function testHalfOpenExecutesExactlyOneAttemptWithMaxAttemptsGreaterThanOne(): void
+    {
+        $clock = new FrozenClock();
+
+        $retry = new ConnectionRetry(
+            maxAttempts: 3,
+            retryDelay: 1000,
+            retryCircuitBreaker: true,
+            retryCircuitBreakerThreshold: 1,
+            retryCircuitBreakerTimeout: 2,
+            clock: $clock,
+        );
+
+        try {
+            $retry->withRetry(function (): void {
+                throw new \AMQPConnectionException('Connection failed');
+            });
+        } catch (RetryExhaustedException) {
+        }
+
+        $this->assertTrue($retry->isCircuitOpen());
+
+        $clock->advance(3);
+
+        $attempt = 0;
+        try {
+            $retry->withRetry(function () use (&$attempt): void {
+                $attempt++;
+                throw new \AMQPConnectionException('Connection failed');
+            });
+        } catch (\AMQPConnectionException) {
+        }
+
+        $this->assertSame(1, $attempt, 'Half-open probe must execute exactly once regardless of maxAttempts');
+    }
+
+    public function testHalfOpenProbeFailureReopensCircuit(): void
+    {
+        $clock = new FrozenClock();
+
+        $retry = new ConnectionRetry(
+            maxAttempts: 3,
+            retryDelay: 1000,
+            retryCircuitBreaker: true,
+            retryCircuitBreakerThreshold: 1,
+            retryCircuitBreakerTimeout: 2,
+            clock: $clock,
+        );
+
+        try {
+            $retry->withRetry(function (): void {
+                throw new \AMQPConnectionException('Connection failed');
+            });
+        } catch (RetryExhaustedException) {
+        }
+
+        $clock->advance(3);
+
+        $retry->isCircuitOpen();
+        $this->assertSame(CircuitState::HALF_OPEN, $retry->getState());
+
+        try {
+            $retry->withRetry(function (): void {
+                throw new \AMQPConnectionException('Probe failed');
+            });
+        } catch (\AMQPConnectionException) {
+        }
+
+        $this->assertSame(CircuitState::OPEN, $retry->getState());
+    }
+
+    public function testHalfOpenProbePermanentFailureCodeRecordsToBreaker(): void
+    {
+        $clock = new FrozenClock();
+
+        $retry = new ConnectionRetry(
+            maxAttempts: 3,
+            retryDelay: 1000,
+            retryCircuitBreaker: true,
+            retryCircuitBreakerThreshold: 1,
+            retryCircuitBreakerTimeout: 2,
+            clock: $clock,
+        );
+
+        try {
+            $retry->withRetry(function (): void {
+                throw new \AMQPConnectionException('Connection failed');
+            });
+        } catch (RetryExhaustedException) {
+        }
+
+        $clock->advance(3);
+
+        $retry->isCircuitOpen();
+        $this->assertSame(CircuitState::HALF_OPEN, $retry->getState());
+
+        $attempt = 0;
+        try {
+            $retry->withRetry(function () use (&$attempt): void {
+                $attempt++;
+                throw new \AMQPQueueException('Queue not found', 404);
+            });
+        } catch (\AMQPQueueException) {
+        }
+
+        $this->assertSame(1, $attempt, 'Permanent failure code in HALF_OPEN must execute exactly once');
+        $this->assertSame(CircuitState::OPEN, $retry->getState());
+    }
+
+    public function testHalfOpenProbeSuccessAdvancesToClosedAfterThreshold(): void
+    {
+        $clock = new FrozenClock();
+
+        $retry = new ConnectionRetry(
+            maxAttempts: 3,
+            retryDelay: 1000,
+            retryCircuitBreaker: true,
+            retryCircuitBreakerThreshold: 1,
+            retryCircuitBreakerTimeout: 2,
+            retryCircuitBreakerSuccessThreshold: 2,
+            clock: $clock,
+        );
+
+        try {
+            $retry->withRetry(function (): void {
+                throw new \AMQPConnectionException('Connection failed');
+            });
+        } catch (RetryExhaustedException) {
+        }
+
+        $clock->advance(3);
+
+        $retry->isCircuitOpen();
+        $this->assertSame(CircuitState::HALF_OPEN, $retry->getState());
+
+        $retry->withRetry(fn(): string => 'first success');
+        $this->assertSame(CircuitState::HALF_OPEN, $retry->getState(), 'One success under threshold should stay HALF_OPEN');
+
+        $retry->withRetry(fn(): string => 'second success');
+        $this->assertSame(CircuitState::CLOSED, $retry->getState(), 'Second success reaches threshold, should close');
+    }
+
+    public function testHalfOpenProbeNonAmqpExceptionThrowsUnexpected(): void
+    {
+        $clock = new FrozenClock();
+
+        $retry = new ConnectionRetry(
+            maxAttempts: 3,
+            retryDelay: 1000,
+            retryCircuitBreaker: true,
+            retryCircuitBreakerThreshold: 1,
+            retryCircuitBreakerTimeout: 2,
+            clock: $clock,
+        );
+
+        try {
+            $retry->withRetry(function (): void {
+                throw new \AMQPConnectionException('Connection failed');
+            });
+        } catch (RetryExhaustedException) {
+        }
+
+        $clock->advance(3);
+
+        $retry->isCircuitOpen();
+        $this->assertSame(CircuitState::HALF_OPEN, $retry->getState());
+
+        $this->expectException(UnexpectedOperationException::class);
+
+        $retry->withRetry(function (): void {
+            throw new \RuntimeException('Unexpected error');
+        });
+    }
+
     public function testCircuitBreakerSuccessThresholdValidation(): void
     {
         $this->expectException(\InvalidArgumentException::class);


### PR DESCRIPTION
## Summary

The circuit breaker's HALF_OPEN "single trial request" semantics are defeated by the retry loop. The breaker is checked once before the loop; once past that gate, the loop fires up to `maxAttempts` real requests at the service that HALF_OPEN is meant to probe with exactly one.

## Changes

- **`ConnectionRetry::withRetry()`** — After the `isAvailable()` gate passes, check `getState()`. If HALF_OPEN, delegate to `executeHalfOpenProbe()` instead of entering the retry loop.
- **`ConnectionRetry::executeHalfOpenProbe()`** — New private method that executes the operation exactly once, records success/failure directly to the circuit breaker, and does not retry.
- **Tests** — 6 new tests verify:
  - Exactly 1 attempt in HALF_OPEN regardless of `maxAttempts`
  - Probe failure re-opens the circuit
  - Permanent failure codes still record to breaker in HALF_OPEN
  - Probe success advances to CLOSED after `successThreshold`
  - Non-AMQP exception throws `UnexpectedOperationException`
  - Circuit closes after reaching success threshold via probes

Fixes #223