### PR TITLE
fix: classify permanent AMQP failures by exception type instead of unreliable getCode()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- Permanent-failure classification now uses exception **type** (AMQPQueueException/AMQPExchangeException) instead of unreliable `getCode()` integer matching — ext-amqp frequently returns 0 or a librabbitmq errno instead of the AMQP reply code, so a resource-not-found error with code 0 was incorrectly retried, and a connection-level error with code 404 was incorrectly treated as permanent (#224)
+  - `AMQPConnectionException` / `AMQPChannelException` are always transient (reconnectable)
+  - `AMQPQueueException` / `AMQPExchangeException` are always permanent (resource errors won't resolve on retry)
+  - Generic `AMQPException` still falls back to code matching for backward compatibility
 - Circuit-breaker HALF_OPEN single-probe semantics are no longer defeated by the retry loop — when the circuit transitions to HALF_OPEN the operation is executed exactly once (not `retryCount` times), preserving the failure-isolation the feature advertises (#223)
 - Retry jitter is now applied BEFORE the `retry_max_delay` cap — jitter no longer pushes the effective delay up to 25% above the configured maximum (#225)
 - `AmqpStamp::createFromAmqpEnvelope()` no longer drops `priority`, `delivery_mode`, or `timestamp` when their value is `0` — priority 0 is a valid AMQP level that was lost on receive→re-send round-trips (#226)

--- a/src/ConnectionRetry.php
+++ b/src/ConnectionRetry.php
@@ -27,6 +27,32 @@ final class ConnectionRetry implements ConnectionRetryInterface
     /** AMQP error codes that indicate permanent failures - should not retry */
     private const PERMANENT_FAILURE_CODES = [403, 404, 406];
 
+    /**
+     * Determines if an AMQP exception represents a permanent (non-retryable) failure.
+     *
+     * Connection-level exceptions (AMQPConnectionException, AMQPChannelException)
+     * are considered transient — a reconnect may resolve them.
+     * Resource-level exceptions (AMQPQueueException, AMQPExchangeException)
+     * are considered permanent — the referenced queue/exchange will not appear
+     * on retry.
+     *
+     * For generic AMQPException the getCode() is used as a fallback, but note
+     * that ext-amqp does NOT reliably surface AMQP reply codes there —
+     * getCode() is frequently 0 or a librabbitmq errno.
+     */
+    private function isPermanentFailure(\AMQPException $exception): bool
+    {
+        if ($exception instanceof \AMQPQueueException || $exception instanceof \AMQPExchangeException) {
+            return true;
+        }
+
+        if ($exception instanceof \AMQPConnectionException || $exception instanceof \AMQPChannelException) {
+            return false;
+        }
+
+        return in_array($exception->getCode(), self::PERMANENT_FAILURE_CODES, true);
+    }
+
     private ?CircuitBreaker $circuitBreaker = null;
     private readonly RetryMetrics $metrics;
 
@@ -119,11 +145,10 @@ final class ConnectionRetry implements ConnectionRetryInterface
 
                 return $result;
             } catch (\AMQPException $exception) {
-                // Only retry on recoverable AMQP errors (connection/channel issues)
-                // Don't retry on permanent failures (not found, access denied, precondition failed)
-                if (in_array($exception->getCode(), self::PERMANENT_FAILURE_CODES, true)) {
+                if ($this->isPermanentFailure($exception)) {
                     $this->logger?->warning('Permanent AMQP failure, not retrying', [
                         'code' => $exception->getCode(),
+                        'type' => $exception::class,
                         'error' => $exception->getMessage(),
                     ]);
                     throw $exception;

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -123,22 +123,41 @@ class ConnectionRetryTest extends TestCase
         $this->assertSame(3, $attempt);
     }
 
-    public function testRetryOnExchangeException(): void
+    public function testNoRetryOnExchangeException(): void
     {
         $attempt = 0;
         $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
 
-        $this->expectException(RetryExhaustedException::class);
-
-        $retry->withRetry(function () use (&$attempt): void {
-            $attempt++;
-            throw new \AMQPExchangeException('Exchange error after reconnect');
-        });
-
-        $this->assertSame(3, $attempt);
+        try {
+            $retry->withRetry(function () use (&$attempt): void {
+                $attempt++;
+                throw new \AMQPExchangeException('Exchange error');
+            });
+            $this->fail('Expected AMQPExchangeException to be thrown');
+        } catch (\AMQPExchangeException $e) {
+            $this->assertSame(1, $attempt, 'Permanent failure should not trigger retry');
+            $this->assertSame('Exchange error', $e->getMessage());
+        }
     }
 
-    public function testRetryOnQueueException(): void
+    public function testNoRetryOnQueueException(): void
+    {
+        $attempt = 0;
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
+
+        try {
+            $retry->withRetry(function () use (&$attempt): void {
+                $attempt++;
+                throw new \AMQPQueueException('Queue error');
+            });
+            $this->fail('Expected AMQPQueueException to be thrown');
+        } catch (\AMQPQueueException $e) {
+            $this->assertSame(1, $attempt, 'Permanent failure should not trigger retry');
+            $this->assertSame('Queue error', $e->getMessage());
+        }
+    }
+
+    public function testRetryOnConnectionExceptionWithPermanentCode(): void
     {
         $attempt = 0;
         $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
@@ -147,10 +166,72 @@ class ConnectionRetryTest extends TestCase
 
         $retry->withRetry(function () use (&$attempt): void {
             $attempt++;
-            throw new \AMQPQueueException('Queue error after reconnect');
+            throw new \AMQPConnectionException('Connection lost', 404);
         });
 
-        $this->assertSame(3, $attempt);
+        $this->assertSame(3, $attempt, 'Connection exception with code 404 should be transient, not permanent');
+    }
+
+    public function testRetryOnChannelExceptionWithPermanentCode(): void
+    {
+        $attempt = 0;
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
+
+        $this->expectException(RetryExhaustedException::class);
+
+        $retry->withRetry(function () use (&$attempt): void {
+            $attempt++;
+            throw new \AMQPChannelException('Channel error', 404);
+        });
+
+        $this->assertSame(3, $attempt, 'Channel exception with code 404 should be transient, not permanent');
+    }
+
+    public function testNoRetryOnQueueExceptionWithZeroCode(): void
+    {
+        $attempt = 0;
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
+
+        try {
+            $retry->withRetry(function () use (&$attempt): void {
+                $attempt++;
+                throw new \AMQPQueueException('Queue not found', 0);
+            });
+            $this->fail('Expected AMQPQueueException to be thrown');
+        } catch (\AMQPQueueException $e) {
+            $this->assertSame(1, $attempt, 'Queue exception with code 0 should be permanent by type');
+        }
+    }
+
+    public function testNoRetryOnExchangeExceptionWithZeroCode(): void
+    {
+        $attempt = 0;
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
+
+        try {
+            $retry->withRetry(function () use (&$attempt): void {
+                $attempt++;
+                throw new \AMQPExchangeException('Exchange not found', 0);
+            });
+            $this->fail('Expected AMQPExchangeException to be thrown');
+        } catch (\AMQPExchangeException $e) {
+            $this->assertSame(1, $attempt, 'Exchange exception with code 0 should be permanent by type');
+        }
+    }
+
+    public function testRetryOnGenericAmqpExceptionWithZeroCode(): void
+    {
+        $attempt = 0;
+        $retry = new ConnectionRetry(maxAttempts: 3, retryDelay: 1000);
+
+        $this->expectException(RetryExhaustedException::class);
+
+        $retry->withRetry(function () use (&$attempt): void {
+            $attempt++;
+            throw new \AMQPException('Generic error', 0);
+        });
+
+        $this->assertSame(3, $attempt, 'Generic AMQPException with code 0 should be transient');
     }
 
     public function testRetrySucceedsOnSecondAttemptWithChannelException(): void

--- a/tests/Unit/ConnectionRetryTest.php
+++ b/tests/Unit/ConnectionRetryTest.php
@@ -198,7 +198,7 @@ class ConnectionRetryTest extends TestCase
                 throw new \AMQPQueueException('Queue not found', 0);
             });
             $this->fail('Expected AMQPQueueException to be thrown');
-        } catch (\AMQPQueueException $e) {
+        } catch (\AMQPQueueException) {
             $this->assertSame(1, $attempt, 'Queue exception with code 0 should be permanent by type');
         }
     }
@@ -214,7 +214,7 @@ class ConnectionRetryTest extends TestCase
                 throw new \AMQPExchangeException('Exchange not found', 0);
             });
             $this->fail('Expected AMQPExchangeException to be thrown');
-        } catch (\AMQPExchangeException $e) {
+        } catch (\AMQPExchangeException) {
             $this->assertSame(1, $attempt, 'Exchange exception with code 0 should be permanent by type');
         }
     }


### PR DESCRIPTION
## Description

Fixes #224

The `PERMANENT_FAILURE_CODES = [403, 404, 406]` check relied on `AMQPException::getCode()`, but ext-amqp does not reliably surface AMQP reply codes there — `getCode()` is frequently `0` or a librabbitmq errno.

### Changes

- **New `isPermanentFailure()` method** classifying by exception type:
  - `AMQPConnectionException` / `AMQPChannelException` → always transient (reconnectable)
  - `AMQPQueueException` / `AMQPExchangeException` → always permanent (resource errors won't resolve on retry)
  - Generic `AMQPException` (base class) → falls back to code matching for backward compatibility
- Updated `withRetry()` to use the new method
- Added 'type' field to permanent-failure warning log context

### Testing

- **New tests:**
  - `testRetryOnConnectionExceptionWithPermanentCode` — connection exception with code 404 is retried (transient by type)
  - `testRetryOnChannelExceptionWithPermanentCode` — channel exception with code 404 is retried (transient by type)
  - `testNoRetryOnQueueExceptionWithZeroCode` — queue exception with code 0 is permanent (key bug fix)
  - `testNoRetryOnExchangeExceptionWithZeroCode` — exchange exception with code 0 is permanent (key bug fix)
  - `testRetryOnGenericAmqpExceptionWithZeroCode` — generic AMQPException with code 0 is transient (backward compat)
- **Updated tests:**
  - `testRetryOnExchangeException` → renamed to `testNoRetry...`, now expects permanent behavior
  - `testRetryOnQueueException` → renamed to `testNoRetry...`, now expects permanent behavior

All 357 unit tests pass (6728 assertions). E2E failures are pre-existing (no broker available).