### PR TITLE
fix: replace fragile str_contains consumer-timeout detection with AMQPQueueException type matching (#222)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- "Consumer timeout" detection now uses exception **type** (`AMQPQueueException`) instead of fragile `str_contains` on message text — substring collision swallowed real errors with "Consumer timeout" in message, and wording variations caused benign timeouts to crash workers. Timeout is only swallowed when no messages were collected (true empty poll); partial batches are returned (#222)
 - Permanent-failure classification now uses exception **type** (AMQPQueueException/AMQPExchangeException) instead of unreliable `getCode()` integer matching — ext-amqp frequently returns 0 or a librabbitmq errno instead of the AMQP reply code, so a resource-not-found error with code 0 was incorrectly retried, and a connection-level error with code 404 was incorrectly treated as permanent (#224)
   - `AMQPConnectionException` / `AMQPChannelException` are always transient (reconnectable)
   - `AMQPQueueException` / `AMQPExchangeException` are always permanent (resource errors won't resolve on retry)

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -115,12 +115,10 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
 
             try {
                 $queue->consume($callback, AMQP_JUST_CONSUME, $queue->getConsumerTag());
-            } catch (\AMQPQueueException $exception) {
+            } catch (\AMQPQueueException) {
                 if ($this->messages !== []) {
                     break;
                 }
-            } catch (\AMQPException $exception) {
-                throw $exception;
             }
         }
 

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -115,10 +115,12 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
 
             try {
                 $queue->consume($callback, AMQP_JUST_CONSUME, $queue->getConsumerTag());
-            } catch (\AMQPException $exception) {
-                if (!str_contains($exception->getMessage(), 'Consumer timeout')) {
-                    throw $exception;
+            } catch (\AMQPQueueException $exception) {
+                if ($this->messages !== []) {
+                    break;
                 }
+            } catch (\AMQPException $exception) {
+                throw $exception;
             }
         }
 

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -76,7 +76,7 @@ class ReceiverTest extends TestCase
         $this->queue
             ->expects($this->once())
             ->method('consume')
-            ->willThrowException(new \AMQPException('Consumer timeout exceed'));
+            ->willThrowException(new \AMQPQueueException('Consumer timeout exceeded'));
 
         $this->queue
             ->method('getConsumerTag')
@@ -90,47 +90,6 @@ class ReceiverTest extends TestCase
         $result = $receiver->get();
 
         $this->assertSame([], $result);
-    }
-
-    /**
-     * @dataProvider timeoutMessageVariationProvider
-     */
-    public function testGetReturnsEmptyArrayForTimeoutMessageVariation(string $message): void
-    {
-        $options = ['queue' => 'test_queue'];
-
-        $receiver = $this->createReceiverWithQueue($options);
-
-        $this->queue
-            ->expects($this->once())
-            ->method('consume')
-            ->willThrowException(new \AMQPException($message));
-
-        $this->queue
-            ->method('getConsumerTag')
-            ->willReturn('test_tag');
-
-        $this->connection
-            ->expects($this->once())
-            ->method('checkHeartbeat')
-            ->willReturn(false);
-
-        $result = $receiver->get();
-
-        $this->assertSame([], $result, "Failed for message: {$message}");
-    }
-
-    /**
-     * @return array<string, array{0: string}>
-     */
-    public static function timeoutMessageVariationProvider(): array
-    {
-        return [
-            'original message' => ['Consumer timeout exceed'],
-            'grammatically correct' => ['Consumer timeout exceeded'],
-            'with verb has been' => ['Consumer timeout has been exceeded'],
-            'with colon' => ['Consumer timeout: exceeded'],
-        ];
     }
 
     public function testGetReturnsMessageWhenAvailable(): void
@@ -358,7 +317,7 @@ class ReceiverTest extends TestCase
 
         $this->queue
             ->method('consume')
-            ->willThrowException(new \AMQPException('Consumer timeout exceed'));
+            ->willThrowException(new \AMQPQueueException('Consumer timeout exceeded'));
 
         $this->queue
             ->method('getConsumerTag')
@@ -396,6 +355,31 @@ class ReceiverTest extends TestCase
 
         $this->expectException(\AMQPException::class);
         $this->expectExceptionMessage('Connection failed');
+
+        $receiver->get();
+    }
+
+    public function testGetRethrowsNonTimeoutExceptionWithConsumerTimeoutInMessage(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $receiver = $this->createReceiverWithQueue($options);
+
+        $this->queue
+            ->expects($this->once())
+            ->method('consume')
+            ->willThrowException(new \AMQPException('Consumer timeout in wrong context'));
+
+        $this->queue
+            ->method('getConsumerTag')
+            ->willReturn('test_tag');
+
+        $this->connection
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->expectException(\AMQPException::class);
+        $this->expectExceptionMessage('Consumer timeout in wrong context');
 
         $receiver->get();
     }
@@ -1290,7 +1274,7 @@ class ReceiverTest extends TestCase
                 $bodyProp = $refl->getProperty('body');
                 $bodyProp->setValue($amqpEnvelope, '{"data":"test"}');
                 $callback($amqpEnvelope);
-                throw new \AMQPException('Consumer timeout exceed');
+                throw new \AMQPQueueException('Consumer timeout exceeded');
             });
 
         $this->queue


### PR DESCRIPTION
## Summary

Replaces fragile `str_contains($e->getMessage(), 'Consumer timeout')` timeout detection with exception **type** matching (`AMQPQueueException`). String-matching on message text is fragile across librabbitmq versions, locale-dependent error messages, and can silently swallow real errors that happen to contain 'Consumer timeout' in their message text.

## Changes

- `src/Receiver.php`: catch `AMQPQueueException` instead of `AMQPException` + `str_contains` message match
- Only swallow the exception when `$this->messages === []` (true empty poll timeout)
- When messages were already collected before the timeout, `break` and return the partial batch
- Non-`AMQPQueueException` exceptions (connection/channel errors) always propagate immediately
- Removed `timeoutMessageVariationProvider` data provider tests — type-based matching makes message variations irrelevant

## Testing

- All existing unit tests pass (354 tests)
- All 41 E2E failures are pre-existing (no broker available)
- New test: `testGetRethrowsNonTimeoutExceptionWithConsumerTimeoutInMessage` — confirms `AMQPException` with 'Consumer timeout' in message is NOT swallowed

Closes #222