### PR TITLE
fix: reset consumer state on AMQP exception — prevent silent stall on dead consumer tag (#221)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@
   - Added `Receiver::close()` / `AmqpTransport::close()` flush of pending acks on worker shutdown
   - Eager consumption no longer delays first message until full batch is collected
   - Lost ack redelivery on worker stop is eliminated — pending acks are flushed before disconnect
+- `Receiver::get()` no longer silently stalls on server-side consumer cancellation — catching `\AMQPException` now resets consumer state (`queues`, `unacked`, `lastUnacked`) and clears channel cache, forcing fresh consumer re‑registration on the next `get()` call (#221)
+  - Previously, `AMQP_JUST_CONSUME` against a dead consumer tag blocked forever or panicked silently
+  - Caught exceptions now trigger `ConnectionInterface::clearChannelCache()`, queue‑list reset, and unacked‑state reset
 
 ## [v0.2.0] - 2026-04-22
 

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -115,7 +115,12 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
 
             try {
                 $queue->consume($callback, AMQP_JUST_CONSUME, $queue->getConsumerTag());
-            } catch (\AMQPQueueException) {
+            } catch (\AMQPException) {
+                $this->connection->clearChannelCache();
+                $this->queues = [];
+                $this->unacked = [];
+                $this->lastUnacked = [];
+
                 if ($this->messages !== []) {
                     break;
                 }

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -334,7 +334,7 @@ class ReceiverTest extends TestCase
         $receiver->get();
     }
 
-    public function testGetRethrowsNonTimeoutAmqpException(): void
+    public function testGetHandlesAmqpExceptionGracefully(): void
     {
         $options = ['queue' => 'test_queue'];
 
@@ -353,13 +353,14 @@ class ReceiverTest extends TestCase
             ->method('checkHeartbeat')
             ->willReturn(false);
 
-        $this->expectException(\AMQPException::class);
-        $this->expectExceptionMessage('Connection failed');
+        $this->connection
+            ->expects($this->once())
+            ->method('clearChannelCache');
 
         $receiver->get();
     }
 
-    public function testGetRethrowsNonTimeoutExceptionWithConsumerTimeoutInMessage(): void
+    public function testGetResetsQueuesOnAmqpException(): void
     {
         $options = ['queue' => 'test_queue'];
 
@@ -368,7 +369,7 @@ class ReceiverTest extends TestCase
         $this->queue
             ->expects($this->once())
             ->method('consume')
-            ->willThrowException(new \AMQPException('Consumer timeout in wrong context'));
+            ->willThrowException(new \AMQPException('Channel error'));
 
         $this->queue
             ->method('getConsumerTag')
@@ -378,10 +379,116 @@ class ReceiverTest extends TestCase
             ->method('checkHeartbeat')
             ->willReturn(false);
 
-        $this->expectException(\AMQPException::class);
-        $this->expectExceptionMessage('Consumer timeout in wrong context');
+        $this->connection
+            ->method('clearChannelCache');
 
         $receiver->get();
+
+        $reflection = new \ReflectionClass(Receiver::class);
+        $queuesProperty = $reflection->getProperty('queues');
+        $this->assertSame([], $queuesProperty->getValue($receiver));
+    }
+
+    public function testGetResetsUnackedMessagesOnAmqpException(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $receiver = $this->createReceiverWithQueue($options);
+
+        $this->queue
+            ->expects($this->once())
+            ->method('consume')
+            ->willThrowException(new \AMQPException('Consumer cancelled'));
+
+        $this->queue
+            ->method('getConsumerTag')
+            ->willReturn('test_tag');
+
+        $this->connection
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->connection
+            ->method('clearChannelCache');
+
+        $receiver->get();
+
+        $reflection = new \ReflectionClass(Receiver::class);
+        $this->assertSame([], $reflection->getProperty('unacked')->getValue($receiver));
+        $this->assertSame([], $reflection->getProperty('lastUnacked')->getValue($receiver));
+    }
+
+    public function testGetReturnsMessagesWhenExceptionOccursAfterPartialConsume(): void
+    {
+        $options = ['queue' => 'test_queue', 'batch_size' => 5];
+
+        $this->serializer
+            ->method('decode')
+            ->willReturn(new Envelope(new \stdClass()));
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $reflection = new \ReflectionClass(Receiver::class);
+        $queuesProperty = $reflection->getProperty('queues');
+        $queuesProperty->setValue($receiver, ['test_queue' => $this->queue]);
+
+        $callbackCapture = null;
+
+        $this->queue
+            ->expects($this->once())
+            ->method('consume')
+            ->willReturnCallback(function (?callable $callback, int $flags, ?string $consumerTag) use (&$callbackCapture): void {
+                $callbackCapture = $callback;
+                // Deliver one message via callback before throwing
+                $amqpEnvelope = new \AMQPEnvelope();
+                $refl = new \ReflectionClass(\AMQPEnvelope::class);
+                $bodyProp = $refl->getProperty('body');
+                $bodyProp->setValue($amqpEnvelope, '{"data":"test"}');
+                $callback($amqpEnvelope);
+                throw new \AMQPException('Consumer cancelled server-side');
+            });
+
+        $this->queue
+            ->method('getConsumerTag')
+            ->willReturn('test_tag');
+
+        $this->connection
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->connection
+            ->method('clearChannelCache');
+
+        $result = $receiver->get();
+
+        $this->assertCount(1, $result);
+    }
+
+    public function testGetReturnsEmptyArrayOnAmqpExceptionWithoutMessages(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $receiver = $this->createReceiverWithQueue($options);
+
+        $this->queue
+            ->expects($this->once())
+            ->method('consume')
+            ->willThrowException(new \AMQPException('Consumer cancelled server-side'));
+
+        $this->queue
+            ->method('getConsumerTag')
+            ->willReturn('test_tag');
+
+        $this->connection
+            ->method('checkHeartbeat')
+            ->willReturn(false);
+
+        $this->connection
+            ->method('clearChannelCache');
+
+        $result = $receiver->get();
+
+        $this->assertSame([], $result);
     }
 
     public function testConnectIsLazy(): void


### PR DESCRIPTION
## Summary

Fixes silent worker stall when the broker cancels a consumer server-side and `Receiver::get()` re-enters consumption with `AMQP_JUST_CONSUME` against a dead consumer tag.

## Problem

`connect()` registers consumers once (via `consume(null, AMQP_NOPARAM)`) and caches them in `$this->queues`. Each subsequent `get()` calls `consume($callback, AMQP_JUST_CONSUME, $queue->getConsumerTag())` — reusing the original consumer tag without re-sending `basic.consume`.

If the broker cancels the consumer server-side (consumer-cancel notification, queue redeclare, channel error swallowed by ext-amqp), the cached consumer tag is dead. The next `get()` either:

- **Blocks forever** — `consume()` waits for deliveries that will never arrive  
- **Throws** — caught by the fragile `AMQPQueueException` handler that only `break`s if messages exist, otherwise silently passes through

## Fix

In `Receiver::get()`, when `consume()` throws any `\AMQPException`:

1. Call `ConnectionInterface::clearChannelCache()` — invalidates the stale channel  
2. Reset `$this->queues = []` — forces `connect()` to re-register consumers next call  
3. Reset `$this->unacked = []` and `$this->lastUnacked = []` — stale delivery tags are discarded  

If messages were already collected from other queues, they are returned normally. Otherwise an empty array is returned and the next `get()` call re-establishes everything fresh.

## Testing

- **testGetHandlesAmqpExceptionGracefully** — `\AMQPException` no longer rethrows, returns empty  
- **testGetResetsQueuesOnAmqpException** — verifies `$queues` is reset after exception  
- **testGetResetsUnackedMessagesOnAmqpException** — verifies `$unacked`/`$lastUnacked` are reset  
- **testGetReturnsMessagesWhenExceptionOccursAfterPartialConsume** — partial batch preserved across exception  
- **testGetReturnsEmptyArrayOnAmqpExceptionWithoutMessages** — empty returned when no messages collected  

Closes #221