### PR TITLE
fix: normalizeValue mis-casts scientific-notation numbers (#246)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- `normalizeValue` no longer silently truncates scientific-notation numbers (e.g. `1e3` → `1000.0` instead of `1`) — DSN query parameters like `read_timeout=1e5` now produce the correct float value (#246)
 - "Consumer timeout" detection now uses exception **type** (`AMQPQueueException`) instead of fragile `str_contains` on message text — substring collision swallowed real errors with "Consumer timeout" in message, and wording variations caused benign timeouts to crash workers. Timeout is only swallowed when no messages were collected (true empty poll); partial batches are returned (#222)
 - Permanent-failure classification now uses exception **type** (AMQPQueueException/AMQPExchangeException) instead of unreliable `getCode()` integer matching — ext-amqp frequently returns 0 or a librabbitmq errno instead of the AMQP reply code, so a resource-not-found error with code 0 was incorrectly retried, and a connection-level error with code 404 was incorrectly treated as permanent (#224)
   - `AMQPConnectionException` / `AMQPChannelException` are always transient (reconnectable)

--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -205,7 +205,11 @@ final class DsnParser
     private function normalizeValue(mixed $value): mixed
     {
         if (is_numeric($value)) {
-            return str_contains((string) $value, '.') ? (float) $value : (int) $value;
+            $strValue = (string) $value;
+            if (stripos($strValue, 'e') !== false) {
+                return (float) $strValue;
+            }
+            return str_contains($strValue, '.') ? (float) $strValue : (int) $strValue;
         }
 
         if ($value === 'true') {

--- a/tests/Unit/DsnParserTest.php
+++ b/tests/Unit/DsnParserTest.php
@@ -249,4 +249,63 @@ class DsnParserTest extends TestCase
         $this->assertSame('user name', $result['user']);
         $this->assertSame('pass+word', $result['password']);
     }
+
+    public function testNormalizeValueHandlesScientificNotationUpperCase(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost/%2f/my_exchange?read_timeout=1E5');
+
+        $this->assertSame(100000.0, $result['read_timeout']);
+    }
+
+    public function testNormalizeValueHandlesScientificNotationLowerCase(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost/%2f/my_exchange?read_timeout=1e5');
+
+        $this->assertSame(100000.0, $result['read_timeout']);
+    }
+
+    public function testNormalizeValueHandlesScientificNotationWithDecimal(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost/%2f/my_exchange?read_timeout=2.5e3');
+
+        $this->assertSame(2500.0, $result['read_timeout']);
+    }
+
+    public function testNormalizeValueHandlesNegativeScientificNotation(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost/%2f/my_exchange?read_timeout=1e-2');
+
+        $this->assertSame(0.01, $result['read_timeout']);
+    }
+
+    public function testNormalizeValueDoesNotAffectPlainIntegers(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost/%2f/my_exchange?heartbeat=60');
+
+        $this->assertSame(60, $result['heartbeat']);
+        $this->assertIsInt($result['heartbeat']);
+    }
+
+    public function testNormalizeValueDoesNotAffectPlainFloats(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost/%2f/my_exchange?read_timeout=5.5');
+
+        $this->assertSame(5.5, $result['read_timeout']);
+        $this->assertIsFloat($result['read_timeout']);
+    }
+
+    public function testNormalizeValueDoesNotAffectNonNumericStrings(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost/%2f/my_exchange?queue=my_queue');
+
+        $this->assertSame('my_queue', $result['queue']);
+        $this->assertIsString($result['queue']);
+    }
 }


### PR DESCRIPTION
## Summary

`normalizeValue()` uses `is_numeric()` to detect numbers, then checks for `.` to decide between `(int)` and `(float)`. PHP's `is_numeric()` returns `true` for scientific-notation strings like `"1e5"` or `"2E10"`, but these contain no dot — so they get cast to `(int)`, silently truncating `1e5` (which should be `100000`) down to `1`.

## Changes

- **src/DsnParser.php**: Added detection of scientific notation (`e`/`E`) in `normalizeValue()` and cast to `(float)` in that branch
- **tests/Unit/DsnParserTest.php**: Added 6 test cases covering:
  - Uppercase scientific notation (`1E5`)
  - Lowercase scientific notation (`1e5`)
  - Scientific notation with decimal (`2.5e3`)
  - Negative exponent (`1e-2`)
  - Regression: plain integers still return `int`
  - Regression: plain floats still return `float`
- **CHANGELOG.md**: Entry under `### Fixed`

## Verification

- All 364 unit tests pass
- PHPStan: No errors
- PHP CS Fixer: Clean
- Rector: Clean

Closes #246