### PR TITLE
fix: create retry topology for all queues in multi-queue mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- Retry topology (exchange + per-queue retry queues) is now created in multi-queue (`queues`) mode — previously `setupRetryQueue()` early-returned when only `queues` (plural) was configured, causing publish failures to non-existent `_retry` targets (#218)
 - `normalizeValue` no longer silently truncates scientific-notation numbers (e.g. `1e3` → `1000.0` instead of `1`) — DSN query parameters like `read_timeout=1e5` now produce the correct float value (#246)
 - "Consumer timeout" detection now uses exception **type** (`AMQPQueueException`) instead of fragile `str_contains` on message text — substring collision swallowed real errors with "Consumer timeout" in message, and wording variations caused benign timeouts to crash workers. Timeout is only swallowed when no messages were collected (true empty poll); partial batches are returned (#222)
 - Permanent-failure classification now uses exception **type** (AMQPQueueException/AMQPExchangeException) instead of unreliable `getCode()` integer matching — ext-amqp frequently returns 0 or a librabbitmq errno instead of the AMQP reply code, so a resource-not-found error with code 0 was incorrectly retried, and a connection-level error with code 404 was incorrectly treated as permanent (#224)

--- a/src/InfrastructureSetup.php
+++ b/src/InfrastructureSetup.php
@@ -238,27 +238,36 @@ final class InfrastructureSetup implements InfrastructureSetupInterface
 
     private function setupRetryQueue(): void
     {
-        if (!isset($this->options['queue'])) {
+        if (isset($this->options['queue'])) {
+            $queues = [$this->options['queue'] => ['binding_keys' => [$this->options['routing_key'] ?? '']]];
+        } elseif (isset($this->options['queues'])) {
+            $queues = $this->options['queues'];
+        } else {
             return;
         }
 
         $retryExchangeName = $this->options['retry_exchange'] ?? $this->options['exchange'] . '_retry';
-        $routingKey = $this->options['routing_key'] ?? '';
-        $retryQueueName = $this->options['queue'] . '_retry';
         $retryExchange = $this->factory->createExchange($this->connection->getChannel());
         $retryExchange->setName($retryExchangeName);
         $retryExchange->setType(\AMQP_EX_TYPE_DIRECT);
         $retryExchange->setFlags(\AMQP_DURABLE);
         $retryExchange->declareExchange();
-        $retryQueue = $this->factory->createQueue($this->connection->getChannel());
-        $retryQueue->setName($retryQueueName);
-        $retryQueue->setFlags(\AMQP_DURABLE);
-        $retryQueue->setArguments($this->options['retry_queue_arguments'] ?? [
-            'x-dead-letter-exchange' => $this->options['exchange'],
-            'x-dead-letter-routing-key' => $routingKey,
-        ]);
-        $retryQueue->declareQueue();
-        $retryQueue->bind($retryExchangeName, $routingKey . '_retry');
+
+        foreach ($queues as $queueName => $queueConfig) {
+            $bindingKeys = $queueConfig['binding_keys'] ?? [''];
+            $routingKey = $bindingKeys[0] ?? '';
+            $retryQueueName = $queueName . '_retry';
+
+            $retryQueue = $this->factory->createQueue($this->connection->getChannel());
+            $retryQueue->setName($retryQueueName);
+            $retryQueue->setFlags(\AMQP_DURABLE);
+            $retryQueue->setArguments($this->options['retry_queue_arguments'] ?? [
+                'x-dead-letter-exchange' => $this->options['exchange'],
+                'x-dead-letter-routing-key' => $routingKey,
+            ]);
+            $retryQueue->declareQueue();
+            $retryQueue->bind($retryExchangeName, $routingKey . '_retry');
+        }
     }
 
     /**

--- a/tests/Unit/InfrastructureSetupTest.php
+++ b/tests/Unit/InfrastructureSetupTest.php
@@ -433,7 +433,12 @@ class InfrastructureSetupTest extends TestCase
         $this->factory->method('createExchange')
             ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
         $this->factory->method('createQueue')
-            ->willReturnOnConsecutiveCalls($this->queue, $this->retryQueue, $this->createMock(\AMQPQueue::class));
+            ->willReturnOnConsecutiveCalls(
+                $this->queue,
+                $this->createMock(\AMQPQueue::class),
+                $this->retryQueue,
+                $this->createMock(\AMQPQueue::class),
+            );
 
         $this->exchange->method('getName')->willReturn('test_exchange');
 
@@ -447,6 +452,7 @@ class InfrastructureSetupTest extends TestCase
 
         $this->retryExchange->method('setName');
         $this->retryExchange->method('setType');
+        $this->retryExchange->method('setFlags');
         $this->retryExchange->method('declareExchange');
 
         $this->retryQueue->method('setName');
@@ -475,9 +481,10 @@ class InfrastructureSetupTest extends TestCase
 
         $queueA = $this->createMock(\AMQPQueue::class);
         $queueB = $this->createMock(\AMQPQueue::class);
+        $retryQueueB = $this->createMock(\AMQPQueue::class);
 
         $this->factory->method('createQueue')
-            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue);
+            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue, $retryQueueB);
 
         $this->exchange->method('getName')->willReturn('test_exchange');
         $this->exchange->method('setName');
@@ -503,6 +510,7 @@ class InfrastructureSetupTest extends TestCase
 
         $this->retryExchange->method('setName');
         $this->retryExchange->method('setType');
+        $this->retryExchange->method('setFlags');
         $this->retryExchange->method('declareExchange');
 
         $this->retryQueue->method('setName');
@@ -1226,9 +1234,10 @@ class InfrastructureSetupTest extends TestCase
 
         $queueA = $this->createMock(\AMQPQueue::class);
         $queueB = $this->createMock(\AMQPQueue::class);
+        $retryQueueB = $this->createMock(\AMQPQueue::class);
 
         $this->factory->method('createQueue')
-            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue);
+            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue, $retryQueueB);
 
         $this->exchange->method('getName')->willReturn('test_exchange');
         $this->exchange->method('setName');
@@ -1246,6 +1255,7 @@ class InfrastructureSetupTest extends TestCase
 
         $this->retryExchange->method('setName');
         $this->retryExchange->method('setType');
+        $this->retryExchange->method('setFlags');
         $this->retryExchange->method('declareExchange');
 
         $this->retryQueue->method('setName');
@@ -1273,9 +1283,10 @@ class InfrastructureSetupTest extends TestCase
 
         $queueA = $this->createMock(\AMQPQueue::class);
         $queueB = $this->createMock(\AMQPQueue::class);
+        $retryQueueB = $this->createMock(\AMQPQueue::class);
 
         $this->factory->method('createQueue')
-            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue);
+            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue, $retryQueueB);
 
         $this->exchange->method('getName')->willReturn('test_exchange');
         $this->exchange->method('setName');
@@ -1293,6 +1304,7 @@ class InfrastructureSetupTest extends TestCase
 
         $this->retryExchange->method('setName');
         $this->retryExchange->method('setType');
+        $this->retryExchange->method('setFlags');
         $this->retryExchange->method('declareExchange');
 
         $this->retryQueue->method('setName');
@@ -1356,6 +1368,112 @@ class InfrastructureSetupTest extends TestCase
         ];
 
         $setup = new InfrastructureSetup($this->factory, $this->connection, $options);
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesCreatesRetryTopologyForAllQueues(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+        $queueB = $this->createMock(\AMQPQueue::class);
+        $retryQueueB = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $queueB, $this->retryQueue, $retryQueueB);
+
+        $this->exchange->method('getName')->willReturn('my_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->method('setName');
+        $queueA->method('declareQueue');
+        $queueA->method('bind');
+
+        $queueB->method('setName');
+        $queueB->method('declareQueue');
+        $queueB->method('bind');
+
+        $this->retryExchange->expects($this->once())->method('setName')->with('my_exchange_retry');
+        $this->retryExchange->expects($this->once())->method('setType')->with(\AMQP_EX_TYPE_DIRECT);
+        $this->retryExchange->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $this->retryExchange->expects($this->once())->method('declareExchange');
+
+        $this->retryQueue->expects($this->once())->method('setName')->with('orders_retry');
+        $this->retryQueue->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $this->retryQueue->expects($this->once())->method('setArguments')->with([
+            'x-dead-letter-exchange' => 'my_exchange',
+            'x-dead-letter-routing-key' => 'order.created',
+        ]);
+        $this->retryQueue->expects($this->once())->method('declareQueue');
+        $this->retryQueue->expects($this->once())->method('bind')->with('my_exchange_retry', 'order.created_retry');
+
+        $retryQueueB->expects($this->once())->method('setName')->with('notifications_retry');
+        $retryQueueB->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $retryQueueB->expects($this->once())->method('setArguments')->with([
+            'x-dead-letter-exchange' => 'my_exchange',
+            'x-dead-letter-routing-key' => 'notification.*',
+        ]);
+        $retryQueueB->expects($this->once())->method('declareQueue');
+        $retryQueueB->expects($this->once())->method('bind')->with('my_exchange_retry', 'notification.*_retry');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'my_exchange',
+            'queues' => [
+                'orders' => [
+                    'binding_keys' => ['order.created'],
+                ],
+                'notifications' => [
+                    'binding_keys' => ['notification.*'],
+                ],
+            ],
+        ]);
+
+        $setup->setup();
+    }
+
+    public function testSetupWithMultipleQueuesAndCustomRetryExchange(): void
+    {
+        $this->connection->method('getChannel')->willReturn($this->channel);
+        $this->factory->method('createExchange')
+            ->willReturnOnConsecutiveCalls($this->exchange, $this->retryExchange);
+
+        $queueA = $this->createMock(\AMQPQueue::class);
+        $retryQueueA = $this->createMock(\AMQPQueue::class);
+
+        $this->factory->method('createQueue')
+            ->willReturnOnConsecutiveCalls($queueA, $retryQueueA);
+
+        $this->exchange->method('getName')->willReturn('my_exchange');
+        $this->exchange->method('setName');
+        $this->exchange->method('setType');
+        $this->exchange->method('declareExchange');
+
+        $queueA->method('setName');
+        $queueA->method('declareQueue');
+        $queueA->method('bind');
+
+        $this->retryExchange->expects($this->once())->method('setName')->with('custom_retry');
+        $this->retryExchange->expects($this->once())->method('setType')->with(\AMQP_EX_TYPE_DIRECT);
+        $this->retryExchange->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $this->retryExchange->expects($this->once())->method('declareExchange');
+
+        $retryQueueA->expects($this->once())->method('setName')->with('my_queue_retry');
+        $retryQueueA->expects($this->once())->method('setFlags')->with(\AMQP_DURABLE);
+        $retryQueueA->expects($this->once())->method('declareQueue');
+        $retryQueueA->expects($this->once())->method('bind')->with('custom_retry', '_retry');
+
+        $setup = new InfrastructureSetup($this->factory, $this->connection, [
+            'exchange' => 'my_exchange',
+            'retry_exchange' => 'custom_retry',
+            'queues' => [
+                'my_queue' => [],
+            ],
+        ]);
+
         $setup->setup();
     }
 }


### PR DESCRIPTION
Fixes #218

Previously setupRetryQueue() early-returned when no single 'queue' option was set, silently skipping retry topology creation in multi-queue (queues) mode. Any code path that publishes to <exchange>_retry in multi-queue mode targeted a non-existent exchange — publish failure / message loss.

Changes:
- Refactored setupRetryQueue() to handle both single-queue (queue) and multi-queue (queues) modes
- Retry exchange is declared once, then per-queue retry queues using each queue's first binding key as dead-letter routing key
- Updated existing multi-queue tests; added 2 new test cases