### PR TITLE
fix: getMessageCount() no longer starts real consumers via connect()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- `getMessageCount()` no longer starts real consumers via `connect()` — now creates throwaway passive queue objects on a fresh channel and never calls `consume()`. Stats/monitoring calls previously registered server-side consumers, locking messages into prefetch buffer and under-reporting message count (#217)
 - Retry topology (exchange + per-queue retry queues) is now created in multi-queue (`queues`) mode — previously `setupRetryQueue()` early-returned when only `queues` (plural) was configured, causing publish failures to non-existent `_retry` targets (#218)
 - `normalizeValue` no longer silently truncates scientific-notation numbers (e.g. `1e3` → `1000.0` instead of `1`) — DSN query parameters like `read_timeout=1e5` now produce the correct float value (#246)
 - "Consumer timeout" detection now uses exception **type** (`AMQPQueueException`) instead of fragile `str_contains` on message text — substring collision swallowed real errors with "Consumer timeout" in message, and wording variations caused benign timeouts to crash workers. Timeout is only swallowed when no messages were collected (true empty poll); partial batches are returned (#222)

--- a/src/Receiver.php
+++ b/src/Receiver.php
@@ -288,11 +288,14 @@ final class Receiver implements ReceiverInterface, MessageCountAwareInterface
         if ($this->options['auto_setup'] ?? true) {
             $this->setup->setup();
         }
-        $this->connect();
 
+        $channel = $this->connection->getChannel();
         $total = 0;
 
-        foreach ($this->queues as $queue) {
+        foreach ($this->getQueueNames() as $queueName) {
+            $queue = $this->factory->createQueue($channel);
+            $queue->setName($queueName);
+
             $getCount = function () use ($queue): int {
                 $flags = $queue->getFlags();
                 $queue->setFlags($flags | \AMQP_PASSIVE);

--- a/tests/Unit/ReceiverTest.php
+++ b/tests/Unit/ReceiverTest.php
@@ -903,6 +903,63 @@ class ReceiverTest extends TestCase
         $this->assertSame(42, $receiver->getMessageCount());
     }
 
+    public function testGetMessageCountDoesNotStartConsumers(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+        $this->factory->method('createQueue')->willReturn($this->queue);
+
+        $this->queue->method('getFlags')->willReturn(0);
+        $this->queue->method('setFlags');
+        $this->queue->method('declareQueue')->willReturn(42);
+
+        // Consume must NEVER be called from getMessageCount()
+        $this->queue
+            ->expects($this->never())
+            ->method('consume');
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $receiver->getMessageCount();
+    }
+
+    public function testGetMessageCountDoesNotAlterReceiverState(): void
+    {
+        $options = ['queue' => 'test_queue'];
+
+        $channel = $this->createMock(\AMQPChannel::class);
+        $this->connection->method('getChannel')->willReturn($channel);
+        $this->factory->method('createQueue')->willReturn($this->queue);
+
+        $this->queue->method('getFlags')->willReturn(0);
+        $this->queue->method('setFlags');
+        $this->queue->method('declareQueue')->willReturn(42);
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $reflection = new \ReflectionClass(Receiver::class);
+        $queuesProperty = $reflection->getProperty('queues');
+
+        // Before getMessageCount, queues should be empty
+        $this->assertSame([], $queuesProperty->getValue($receiver));
+
+        $receiver->getMessageCount();
+
+        // After getMessageCount, queues should still be empty (no consumer state left)
+        $this->assertSame([], $queuesProperty->getValue($receiver));
+    }
+
+    public function testGetMessageCountReturnsZeroForNoQueues(): void
+    {
+        $options = [];
+
+        $receiver = new Receiver($this->factory, $this->connection, $this->serializer, $options, $this->setup);
+
+        $this->assertSame(0, $receiver->getMessageCount());
+    }
+
     public function testPurgeQueuePurgingConfiguredQueue(): void
     {
         $options = ['queue' => 'test_queue'];


### PR DESCRIPTION
## Summary

`Receiver::getMessageCount()` previously called `connect()` which issues a real `basic.consume` and registers server-side consumers, pulling messages into the client prefetch buffer. A stats/monitoring call therefore returned wrong counts and locked real messages out of delivery.

## Changes

- **src/Receiver.php**: Replaced `connect()` call with fresh per-queue throwaway `AMQPQueue` objects using passive `declareQueue()` to read message counts. No `consume()` is ever called.
- **tests/Unit/ReceiverTest.php**:
  - `testGetMessageCountDoesNotStartConsumers()` — asserts `consume()` is never called from `getMessageCount()`
  - `testGetMessageCountDoesNotAlterReceiverState()` — asserts `$this->queues` remains empty after count
  - `testGetMessageCountReturnsZeroForNoQueues()` — edge case for empty config
- **CHANGELOG.md**: Entry under `### Fixed`

## Impact

`getMessageCount()` is now a pure read operation — no side effects on consumer state, no message locking, no wrong reporting. Fixes a critical issue where monitoring/autoscaling would both under-report and corrupt message delivery.

Closes #217