### PR TITLE
fix: DSN double-slash //exchange now resolves to default vhost (#216)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   - Direct `new ConnectionRetry(retryCount: ...)` calls must use `maxAttempts: ...` instead
 
 ### Fixed
+- DSN double-slash `//exchange` now correctly resolves to default vhost (`/`) — previously the empty vhost segment was collapsed, causing the exchange name to be misinterpreted as vhost (#216)
+- Host-less DSN (`amqp-consoomer:///exchange`) now defaults to `localhost` with default vhost — previously threw "Malformed DSN" (#216)
 - `getMessageCount()` no longer starts real consumers via `connect()` — now creates throwaway passive queue objects on a fresh channel and never calls `consume()`. Stats/monitoring calls previously registered server-side consumers, locking messages into prefetch buffer and under-reporting message count (#217)
 - Retry topology (exchange + per-queue retry queues) is now created in multi-queue (`queues`) mode — previously `setupRetryQueue()` early-returned when only `queues` (plural) was configured, causing publish failures to non-existent `_retry` targets (#218)
 - `normalizeValue` no longer silently truncates scientific-notation numbers (e.g. `1e3` → `1000.0` instead of `1`) — DSN query parameters like `read_timeout=1e5` now produce the correct float value (#246)

--- a/src/DsnParser.php
+++ b/src/DsnParser.php
@@ -55,6 +55,9 @@ final class DsnParser
      */
     public function parse(string $dsn): array
     {
+        // Handle host-less DSN: amqp-consoomer:///exchange → amqp-consoomer://localhost//exchange
+        $dsn = preg_replace('#^([a-z][a-z0-9+.-]*://)/+#', '$1localhost//', $dsn) ?? $dsn;
+
         $info = parse_url($dsn);
         if ($info === false) {
             throw new \InvalidArgumentException('Malformed DSN: ' . $dsn);
@@ -186,11 +189,30 @@ final class DsnParser
      */
     private function parsePath(string $path): array
     {
-        $items = explode('/', trim($path, " \n\r\t\v\0/"));
+        $path = rtrim($path, " \n\r\t\v\0/");
+
+        if ($path === '') {
+            return ['vhost' => '/', 'exchange' => ''];
+        }
+
+        $items = explode('/', $path);
+
+        // Remove the leading empty segment from the '/' prefix
+        if ($items[0] === '') {
+            array_shift($items);
+        }
+
+        $vhost = $items[0];
+        $exchange = $items[1] ?? '';
+
+        // Empty vhost segment (from '//' prefix) means default vhost
+        if ($vhost === '') {
+            $vhost = '/';
+        }
 
         return [
-            'vhost' => rawurldecode($items[0] ?? '/'),
-            'exchange' => rawurldecode($items[1] ?? ''),
+            'vhost' => rawurldecode($vhost),
+            'exchange' => rawurldecode($exchange),
         ];
     }
 

--- a/tests/Unit/DsnParserTest.php
+++ b/tests/Unit/DsnParserTest.php
@@ -308,4 +308,49 @@ class DsnParserTest extends TestCase
         $this->assertSame('my_queue', $result['queue']);
         $this->assertIsString($result['queue']);
     }
+
+    public function testDoubleSlashMeansDefaultVhostWithExchange(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer://guest:guest@localhost:5672//my_exchange');
+
+        $this->assertSame('localhost', $result['host']);
+        $this->assertSame(5672, $result['port']);
+        $this->assertSame('/', $result['vhost']);
+        $this->assertSame('my_exchange', $result['exchange']);
+    }
+
+    public function testDoubleSlashWithAmqpsScheme(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqps-consoomer://guest:guest@localhost//my_exchange');
+
+        $this->assertSame('localhost', $result['host']);
+        $this->assertSame(5671, $result['port']);
+        $this->assertTrue($result['ssl']);
+        $this->assertSame('/', $result['vhost']);
+        $this->assertSame('my_exchange', $result['exchange']);
+    }
+
+    public function testHostLessDsnDefaultsToLocalhostAndDefaultVhost(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer:///my_exchange');
+
+        $this->assertSame('localhost', $result['host']);
+        $this->assertSame('/', $result['vhost']);
+        $this->assertSame('my_exchange', $result['exchange']);
+    }
+
+    public function testHostLessDsnWithQueryParams(): void
+    {
+        $parser = new DsnParser();
+        $result = $parser->parse('amqp-consoomer:///my_exchange?heartbeat=30&queue=my_queue');
+
+        $this->assertSame('localhost', $result['host']);
+        $this->assertSame('/', $result['vhost']);
+        $this->assertSame('my_exchange', $result['exchange']);
+        $this->assertSame(30, $result['heartbeat']);
+        $this->assertSame('my_queue', $result['queue']);
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #216 — there was no DSN syntax that expressed default/empty vhost together with an exchange.

### Changes

- **`DsnParser::parsePath()`**: Fixed path parsing to preserve empty vhost segments. A double-slash `//exchange` prefix in the path now correctly resolves to vhost `/` (default) with the specified exchange name.
- **`DsnParser::parse()`**: Added pre-processing for host-less DSNs (`amqp-consoomer:///exchange`) — injects `localhost` so the form works instead of throwing `Malformed DSN`.
- **Tests**: Added 4 unit tests covering double-slash with plain AMQP, double-slash with AMQPS, host-less DSN, and host-less DSN with query params.

### Examples

| DSN | Before | After |
|-----|--------|-------|
| `amqp-consoomer://host//exchange` | exchange=`` + throw | vhost=`/`, exchange=`exchange` |
| `amqp-consoomer:///exchange` | `Malformed DSN` | localhost, vhost=`/`, exchange=`exchange` |
| `amqp-consoomer://host/vhost/exchange` | vhost=`vhost`, exchange=`exchange` (unchanged) | vhost=`vhost`, exchange=`exchange` |